### PR TITLE
🚑️ server: collect regardless of card status

### DIFF
--- a/.changeset/rotten-terms-move.md
+++ b/.changeset/rotten-terms-move.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+🚑️ collect regardless of card status


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enables collection to proceed irrespective of card status on non-authorization events, while retaining stricter checks for authorization.
> 
> - For `transaction.requested`, fetch card with `status === "ACTIVE"` and acquire mutex as before
> - For `transaction.created`/`completed`, fetch card by `id` without status constraint to permit collection when cards are frozen/locked
> - Remove `findCardById` helper; inline Drizzle queries for cards
> - Add test `over-captures frozen debit` to verify capture works when card becomes `FROZEN` after authorization
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3922e00adf6364613f60618c12f9ba9b7ed511cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->