### PR TITLE
✨ server: integrate sardine

### DIFF
--- a/.changeset/forty-ads-lie.md
+++ b/.changeset/forty-ads-lie.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+✨ integrate sardine

--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -134,6 +134,13 @@ services:
         scope: RUN_TIME
         type: SECRET
         value: ${{ env.ENCRYPTED_REDIS_URL || env.REDIS_URL }}
+      - key: SARDINE_API_KEY
+        scope: RUN_TIME
+        type: SECRET
+        value: ${{ env.ENCRYPTED_SARDINE_API_KEY || env.SARDINE_API_KEY }}
+      - key: SARDINE_API_URL
+        scope: RUN_TIME
+        value: ${{ env.SARDINE_API_URL }}
       - key: SEGMENT_WRITE_KEY
         scope: RUN_TIME
         type: SECRET

--- a/server/hooks/persona.ts
+++ b/server/hooks/persona.ts
@@ -1,5 +1,5 @@
 import { vValidator } from "@hono/valibot-validator";
-import { captureException, getActiveSpan, SEMANTIC_ATTRIBUTE_SENTRY_OP, setContext, setUser } from "@sentry/node";
+import { captureException, getActiveSpan, SEMANTIC_ATTRIBUTE_SENTRY_OP, setUser } from "@sentry/node";
 import { eq } from "drizzle-orm";
 import { Hono } from "hono";
 import type { InferOutput } from "valibot";
@@ -23,8 +23,8 @@ import {
 import database, { credentials } from "../database/index";
 import { createUser } from "../utils/panda";
 import { headerValidator } from "../utils/persona";
+import { customer } from "../utils/sardine";
 import validatorHook from "../utils/validatorHook";
-
 const Session = pipe(
   object({
     type: literal("inquiry-session"),
@@ -56,6 +56,18 @@ export default new Hono().post(
                 attributes: object({
                   status: literal("approved"),
                   referenceId: string(),
+                  emailAddress: string(),
+                  phoneNumber: string(),
+                  birthdate: string(),
+                  nameFirst: string(),
+                  nameMiddle: nullable(string()),
+                  nameLast: string(),
+                  addressStreet1: string(),
+                  addressStreet2: nullable(string()),
+                  addressCity: string(),
+                  addressSubdivision: string(),
+                  addressSubdivisionAbbr: nullable(string()),
+                  addressPostalCode: string(),
                   fields: pipe(
                     object({
                       accountPurpose: object({ value: string() }),
@@ -64,6 +76,7 @@ export default new Hono().post(
                       expectedMonthlyVolume: object({ value: nullable(string()) }),
                       inputSelect: object({ value: string() }),
                       monthlyPurchasesRange: optional(object({ value: string() })),
+                      addressCountryCode: object({ value: string() }),
                     }),
                     check(
                       (fields) => !!fields.annualSalaryRangesUs150000?.value || !!fields.annualSalary.value,
@@ -122,14 +135,12 @@ export default new Hono().post(
   async (c) => {
     getActiveSpan()?.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_OP, "persona.inquiry");
     const {
-      data: {
-        id: personaShareToken,
-        attributes: { fields, referenceId },
-      },
+      data: { id: personaShareToken, attributes },
       session,
       annualSalary,
       expectedMonthlyVolume,
     } = c.req.valid("json").data.attributes.payload;
+    const { referenceId, fields } = attributes;
 
     const credential = await database.query.credentials.findFirst({
       columns: { account: true, pandaId: true },
@@ -141,11 +152,63 @@ export default new Hono().post(
       return c.json({ code: "no credential" }, 200);
     }
     setUser({ id: credential.account });
-    setContext("persona", { inquiryId: personaShareToken });
+    getActiveSpan()?.setAttribute("exa.inquiryId", personaShareToken);
 
     if (credential.pandaId) {
       getActiveSpan()?.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_OP, "persona.inquiry.already-created");
       return c.json({ code: "already created" }, 200);
+    }
+
+    const risk = await customer({
+      flow: { name: "inquiry.approved", type: "account_update" },
+      customer: {
+        id: referenceId,
+        type: "customer",
+        firstName: attributes.nameFirst,
+        lastName: attributes.nameLast,
+        income: {
+          amount:
+            { " < US$ 30.000": 30_000, "US$ 30.000 - US$ 70.000": 70_000, "US$ 70.000 - US$ 150.000": 150_000 }[
+              annualSalary
+            ] ?? 300_000,
+          currencyCode: "USD",
+        },
+        address: {
+          street1: attributes.addressStreet1,
+          city: attributes.addressCity,
+          postalCode: attributes.addressPostalCode,
+          countryCode: fields.addressCountryCode.value,
+          ...(attributes.addressStreet2 && { street2: attributes.addressStreet2 }),
+          ...(attributes.addressSubdivisionAbbr && { regionCode: attributes.addressSubdivisionAbbr }),
+        },
+        phone: attributes.phoneNumber.replaceAll(" ", ""),
+        emailAddress: attributes.emailAddress,
+        dateOfBirth: attributes.birthdate,
+        tags: [
+          {
+            name: "expected_monthly_volume",
+            value:
+              { " < US$ 3000": 3000, "US$ 3.000 - US$ 7.000": 7000, "US$ 7.000 - US$ 15.000": 15_000 }[
+                expectedMonthlyVolume
+              ] ?? 30_000,
+            type: "int",
+          },
+          {
+            name: "source",
+            value: "EXA",
+            type: "string",
+          },
+        ],
+        ...(attributes.nameMiddle && { middleName: attributes.nameMiddle }),
+      },
+      device: { ip: session.attributes.IPAddress },
+    }).catch((error: unknown) => {
+      captureException(error, { level: "error" });
+    });
+
+    if (risk) {
+      getActiveSpan()?.setAttributes({ "exa.risk": risk.level, "exa.score": risk.customer?.score });
+      if (risk.level === "very_high") return c.json({ code: "very high risk" }, 200);
     }
 
     // TODO implement error handling to return 200 if event should not be retried
@@ -161,7 +224,7 @@ export default new Hono().post(
 
     await database.update(credentials).set({ pandaId: id }).where(eq(credentials.id, referenceId));
 
-    setContext("persona", { inquiryId: personaShareToken, pandaId: id });
+    getActiveSpan()?.setAttributes({ "exa.pandaId": id });
 
     return c.json({ id }, 200);
   },

--- a/server/script/openapi.ts
+++ b/server/script/openapi.ts
@@ -23,6 +23,8 @@ process.env.PERSONA_URL = "https://persona.test";
 process.env.PERSONA_WEBHOOK_SECRET = "persona";
 process.env.POSTGRES_URL = "postgres";
 process.env.REDIS_URL = "redis";
+process.env.SARDINE_API_KEY = "sardine";
+process.env.SARDINE_API_URL = "https://api.sardine.ai";
 process.env.SEGMENT_WRITE_KEY = "segment";
 
 /* eslint-disable n/no-process-exit, unicorn/no-process-exit, no-console -- cli */

--- a/server/test/hooks/persona.test.ts
+++ b/server/test/hooks/persona.test.ts
@@ -13,6 +13,7 @@ import { afterEach, beforeAll, describe, expect, inject, it, vi } from "vitest";
 import database, { credentials } from "../../database";
 import app from "../../hooks/persona";
 import * as panda from "../../utils/panda";
+import * as sardine from "../../utils/sardine";
 
 const appClient = testClient(app);
 
@@ -33,6 +34,11 @@ describe("with reference", () => {
   it("creates a panda account", async () => {
     const id = "panda-id";
     vi.spyOn(panda, "createUser").mockResolvedValueOnce({ id });
+    vi.spyOn(sardine, "customer").mockResolvedValueOnce({
+      sessionKey: "test-session-123",
+      status: "Success",
+      level: "low",
+    });
     const response = await appClient.index.$post({
       ...personaPayload,
       json: {

--- a/server/test/mocks/sardine.ts
+++ b/server/test/mocks/sardine.ts
@@ -1,0 +1,8 @@
+import { vi } from "vitest";
+
+vi.mock("../../utils/sardine", async (importOriginal) => ({
+  ...(await importOriginal()),
+  customer: () => Promise.resolve({ status: "Success", level: "low", sessionKey: "mock-session-key" }),
+  feedback: () => Promise.resolve({ status: "Success" }),
+  default: () => Promise.resolve({ amlLevel: "low", level: "low", sessionKey: "mock-session-key", status: "Success" }),
+}));

--- a/server/utils/createCredential.ts
+++ b/server/utils/createCredential.ts
@@ -13,6 +13,7 @@ import { hexToBytes, isAddress } from "viem";
 import { headers as alchemyHeaders } from "./alchemy";
 import authSecret from "./authSecret";
 import decodePublicKey from "./decodePublicKey";
+import { customer } from "./sardine";
 import { identify } from "./segment";
 import database from "../database";
 import { credentials } from "../database/schema";
@@ -57,6 +58,9 @@ export default async function createCredential<C extends string>(
         if (!response.ok) throw new Error(`${response.status} ${await response.text()}`);
       })
       .catch((error: unknown) => captureException(error)),
+    customer({ flow: { name: "signup", type: "signup" }, customer: { id: credentialId } }).catch((error: unknown) =>
+      captureException(error, { level: "error" }),
+    ),
   ]);
   identify({ userId: account });
   return { credentialId, factory: parse(Address, exaAccountFactoryAddress), x, y, auth: expires.getTime() };

--- a/server/utils/sardine.ts
+++ b/server/utils/sardine.ts
@@ -1,0 +1,346 @@
+import domain from "@exactly/common/domain";
+import crypto from "node:crypto";
+import {
+  array,
+  boolean,
+  type BaseIssue,
+  type BaseSchema,
+  length,
+  literal,
+  maxLength,
+  number,
+  object,
+  optional,
+  parse,
+  picklist,
+  pipe,
+  string,
+  type InferInput,
+  variant,
+  toUpperCase,
+  transform,
+} from "valibot";
+
+if (!process.env.SARDINE_API_KEY) throw new Error("missing sardine api key");
+if (!process.env.SARDINE_API_URL) throw new Error("missing sardine api url");
+
+const key = Buffer.from(process.env.SARDINE_API_KEY).toString("base64");
+const baseURL = process.env.SARDINE_API_URL;
+
+export async function customer(data: InferInput<typeof CustomerRequest>, timeout = 10_000) {
+  return await request(CustomerResponse, "/v1/customers", {}, parse(CustomerRequest, data), "POST", timeout);
+}
+export async function feedback(data: InferInput<typeof FeedbackRequest>) {
+  return await request(FeedbackResponse, "/v1/feedbacks", {}, parse(FeedbackRequest, data), "POST");
+}
+export default async function risk(data: InferInput<typeof RiskRequest>) {
+  return await request(RiskResponse, "/v1/issuing/risks", {}, parse(RiskRequest, data), "POST", 500);
+}
+
+async function request<TInput, TOutput, TIssue extends BaseIssue<unknown>>(
+  schema: BaseSchema<TInput, TOutput, TIssue>,
+  url: `/${string}`,
+  headers = {},
+  body?: unknown,
+  method: "GET" | "POST" | "PUT" | "PATCH" = body === undefined ? "GET" : "POST",
+  timeout = 10_000,
+) {
+  const response = await fetch(`${baseURL}${url}`, {
+    method,
+    headers: {
+      ...headers,
+      Authorization: `Basic ${key}`,
+      "X-Request-Id": crypto.randomUUID(),
+      accept: "application/json",
+      "content-type": "application/json",
+    },
+    body: body ? JSON.stringify(body) : undefined,
+    signal: AbortSignal.timeout(timeout),
+  });
+
+  if (!response.ok) throw new Error(`${response.status} ${await response.text()} ${url}`);
+  const rawBody = await response.arrayBuffer();
+  if (rawBody.byteLength === 0) throw new Error(`Empty response body from ${url}`);
+  return parse(schema, JSON.parse(new TextDecoder().decode(rawBody)));
+}
+
+const CustomerRequest = object({
+  flow: object({
+    id: optional(string(), () => crypto.randomUUID()),
+    name: string(),
+    type: picklist([
+      "signup",
+      "onboarding",
+      "login",
+      "transaction",
+      "password_reset",
+      "password_change",
+      "address_change",
+      "email_change",
+      "phone_change",
+      "payment_method_link",
+      "account_update",
+      "logout",
+      "other",
+      "identity_verification",
+      "2fa_update",
+    ]),
+    createdAtMillis: optional(number(), () => Date.now()),
+  }),
+  sessionKey: optional(string(), () => crypto.randomUUID()),
+  customer: optional(
+    object({
+      id: pipe(string(), maxLength(100)),
+      type: optional(
+        picklist([
+          "customer",
+          "sole_proprietor",
+          "vendor",
+          "business",
+          "tenant",
+          "owner",
+          "institutional",
+          "retail",
+          "courier",
+          "driver",
+          "controlling_officer",
+          "beneficial_owner",
+          "applicant",
+          "coapplicant", //cspell:ignore coapplicant
+          "employee",
+          "individual",
+          "llc",
+          "llp",
+          "limited_partnership",
+          "ordinary_partnership",
+          "plc",
+        ]),
+      ),
+      createdAtMillis: optional(number(), () => Date.now()), //cspell:ignore createdAtMillis
+      firstName: optional(pipe(string(), maxLength(100))),
+      middleName: optional(pipe(string(), maxLength(100))),
+      lastName: optional(pipe(string(), maxLength(100))),
+      businessName: optional(pipe(string(), maxLength(100))),
+      address: optional(
+        object({
+          street1: pipe(string(), maxLength(100)),
+          street2: optional(pipe(string(), maxLength(100))),
+          city: pipe(string(), maxLength(100)),
+          regionCode: optional(pipe(string(), maxLength(50))),
+          postalCode: pipe(string(), maxLength(20)),
+          countryCode: pipe(string(), length(2)),
+        }),
+      ),
+      phone: optional(pipe(string(), maxLength(20))),
+      emailAddress: optional(pipe(string(), maxLength(100))),
+      isEmailVerified: optional(boolean(), true),
+      isPhoneVerified: optional(boolean(), true),
+      dateOfBirth: optional(string()),
+      taxId: optional(string()),
+      status: optional(picklist(["enabled", "disabled"]), "enabled"),
+      consentStatus: optional(picklist(["unknown", "optedIn", "optedOut"]), "optedIn"),
+      domain: optional(string(), domain),
+      income: optional(object({ amount: number(), currencyCode: literal("USD") })),
+      tags: optional(
+        array(
+          variant("type", [
+            object({
+              name: string(),
+              type: literal("string"),
+              value: string(),
+            }),
+            object({
+              name: string(),
+              type: literal("int"),
+              value: number(),
+            }),
+          ]),
+        ),
+      ),
+    }),
+  ),
+  device: optional(object({ ip: string(), createdAtMillis: optional(number(), () => Date.now()) })),
+  transaction: optional(
+    object({
+      id: string(),
+      status: optional(picklist(["pending", "accepted", "denied_fraud", "denied"])),
+      createdAtMillis: optional(number(), () => Date.now()),
+      amount: optional(number()),
+      currencyCode: optional(pipe(string(), length(3), toUpperCase())),
+      sentAmount: optional(number()),
+      sentCurrencyCode: optional(pipe(string(), length(3), toUpperCase())),
+      receivedAmount: optional(number()),
+      receivedCurrencyCode: optional(pipe(string(), length(3), toUpperCase())),
+      itemCategory: optional(string()),
+      mcc: optional(string()),
+      actionType: optional(
+        picklist([
+          "buy",
+          "sell",
+          "deposit",
+          "withdraw",
+          "refund",
+          "exchange",
+          "transfer",
+          "multiParty",
+          "loanRepayment",
+          "loanFunding",
+          "credit",
+          "debit",
+        ]),
+        "buy",
+      ),
+      paymentMethod: object({
+        type: literal("card"),
+        card: object({
+          last4: pipe(string(), length(4)),
+          hash: string(),
+          isVerified: optional(boolean(), false),
+          brand: optional(string(), "visa"),
+          issuerCountry: optional(pipe(string(), length(2)), "US"),
+          binCountry: optional(pipe(string(), length(2)), "US"),
+          expiryMonth: optional(pipe(string(), transform(Number), number())),
+          expiryYear: optional(pipe(string(), transform(Number), number())),
+          network: optional(picklist(["visa", "mastercard", "american_express", "other"]), "visa"),
+          type: optional(picklist(["debit", "credit", "prepaid", "virtual", "physical"]), "virtual"),
+          creditCardAuthorization: optional(
+            object({
+              avs: picklist(["match", "nomatch", "not_verified", "error", "nodata"]),
+              avsZip: picklist(["match", "nomatch", "not_verified", "error", "nodata"]),
+              avsStreet: picklist(["match", "nomatch", "not_verified", "error", "nodata"]),
+              cvv: picklist(["match", "nomatch", "not_verified", "not_supported", "error"]),
+              threeDs: picklist([
+                "success",
+                "issuer_not_supported",
+                "signature_verification_failed",
+                "rejected",
+                "frictionless_failed",
+                "error",
+                "bypassed",
+              ]),
+              status: string(),
+              statusCode: string(),
+              processor: string(),
+            }),
+          ),
+        }),
+        firstName: optional(string()),
+        middleName: optional(string()),
+        lastName: optional(string()),
+        billingAddress: optional(
+          object({
+            street1: pipe(string(), maxLength(100)),
+            street2: optional(pipe(string(), maxLength(100))),
+            city: pipe(string(), maxLength(100)),
+            regionCode: optional(pipe(string(), maxLength(50))),
+            postalCode: pipe(string(), maxLength(20)),
+            countryCode: pipe(string(), length(2)),
+            company: optional(pipe(string(), maxLength(100))),
+          }),
+        ),
+      }),
+    }),
+  ),
+});
+
+const CustomerResponse = object({
+  sessionKey: string(),
+  level: picklist(["very_high", "high", "medium", "low", "unknown"]),
+  status: picklist(["Success", "Timeout"]),
+  customer: optional(
+    object({
+      score: number(),
+      level: picklist(["very_high", "high", "medium", "low", "unknown"]),
+      reasonCodes: optional(array(string())),
+    }),
+  ),
+  transaction: optional(
+    object({
+      level: picklist(["very_high", "high", "medium", "low", "unknown"]),
+      amlLevel: picklist(["very_high", "high", "medium", "low", "unknown"]),
+    }),
+  ),
+});
+
+const FeedbackRequest = object({
+  kind: literal("issuing"),
+  customer: object({ id: string() }),
+  transaction: object({ id: string(), amount: optional(number()) }),
+  feedback: variant("type", [
+    object({
+      type: literal("authorization"),
+      status: picklist(["approved", "issuer_declined", "network_declined"]),
+      id: optional(string(), () => crypto.randomUUID()),
+      scope: optional(picklist(["user", "transaction"]), "user"),
+      timeMillis: optional(number(), () => Date.now()), //cspell:ignore timeMillis
+      reason: optional(string()),
+    }),
+    object({
+      type: literal("settlement"),
+      status: picklist([
+        "settled",
+        "chargeback", //cspell:ignore chargeback
+        "merchant_dispute",
+        "chargeback_reversal", //cspell:ignore chargeback_reversal
+        "chargeback_final", //cspell:ignore chargeback_final
+        "refund",
+      ]),
+      id: optional(string(), () => crypto.randomUUID()),
+      scope: optional(picklist(["user", "transaction"]), "user"),
+      timeMillis: optional(number(), () => Date.now()), //cspell:ignore timeMillis
+      reason: optional(string()),
+    }),
+  ]),
+});
+
+const FeedbackResponse = object({ status: string() });
+
+const RiskRequest = pipe(
+  object({
+    sessionKey: pipe(string(), maxLength(100)),
+    customerId: string(),
+    transaction: object({
+      id: string(),
+      amount: number(),
+      currencyCode: pipe(string(), length(3), toUpperCase()),
+      createdAtMillis: optional(number(), () => Date.now()),
+      address: object({ countryCode: pipe(string(), length(2)) }),
+      type: optional(picklist(["purchase", "cash", "return", "balance_inquiry"])),
+      merchant: object({ mcc: string(), id: optional(string()), name: optional(string()) }),
+      status: optional(picklist(["attempt", "pending", "challenge", "success", "failure"])),
+      terminal: object({ type: optional(string(), "unspecified") }),
+    }),
+    card: optional(
+      object({
+        id: string(),
+        network: optional(picklist(["visa", "mastercard", "american_express", "other"]), "visa"),
+        isVirtual: optional(boolean(), true),
+      }),
+    ),
+    checkpoints: optional(array(string())),
+    partnerId: optional(string(), "EXA"),
+    partnerName: optional(string(), "EXA"),
+    workflowName: optional(string(), "issuing_risk"),
+  }),
+  transform((r) => {
+    const { type, operator } = {
+      "00": { type: "pos_terminal", operator: "card_acceptor_operated" },
+      "01": { type: "electronic_commerce", operator: "customer_operated" },
+      "02": { type: "self_service", operator: "customer_operated" },
+      "05": { type: "pos_terminal", operator: "card_acceptor_operated" },
+      "08": { type: "electronic_commerce", operator: "customer_operated" },
+      "51": { type: "authorization", operator: "card_acceptor_operated" },
+      "59": { type: "electronic_commerce", operator: "customer_operated" },
+    }[r.transaction.terminal.type] ?? { type: "unspecified", operator: "unspecified" };
+    return { ...r, transaction: { ...r.transaction, terminal: { type, operator } } };
+  }),
+);
+
+const RiskResponse = object({
+  sessionKey: string(),
+  level: picklist(["very_high", "high", "medium", "low", "unknown"]),
+  status: string(),
+  amlLevel: picklist(["high", "medium", "low"]),
+  score: optional(number()),
+  reasonCodes: optional(array(string())),
+});

--- a/server/vitest.config.mts
+++ b/server/vitest.config.mts
@@ -27,6 +27,8 @@ export default defineConfig({
       PERSONA_WEBHOOK_SECRET: "persona",
       POSTGRES_URL: "postgres",
       REDIS_URL: "redis",
+      SARDINE_API_KEY: "sardine",
+      SARDINE_API_URL: "https://api.sardine.ai",
       SEGMENT_WRITE_KEY: "segment",
       ...(env.NODE_ENV === "e2e" && { APP_DOMAIN: "localhost", DEBUG: "exa:*" }),
     },


### PR DESCRIPTION
closes #480 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Integrates Sardine risk evaluation and event tracking into key user flows.
> 
> - New `utils/sardine.ts` client (`customer`, `feedback`, default `risk`) with strict schemas and request handling
> - Persona webhook (`hooks/persona.ts`): enriches payload, calls `customer` for risk; annotates spans; blocks on `very_high` risk; minor Sentry context refactor
> - Card issuance (`api/card.ts`): after creating a card, sends Sardine `customer` event with card payment method metadata
> - Credential creation (`utils/createCredential.ts`): sends Sardine `customer` event on signup
> - Config: adds `SARDINE_API_KEY` and `SARDINE_API_URL` to runtime env, OpenAPI script, and Vitest config
> - Tests: mock Sardine module and update Persona tests to expect Sardine calls
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 378de8d8ad52fe212886be3d375b0e0133e572dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated Sardine risk/customer/feedback checks into signup, card issuance, and credential flows
  * Risk evaluation runs before account creation and can short-circuit very-high-risk requests

* **Enhancements**
  * Expanded verification payloads with richer contact, address, and demographic fields
  * External calls are non-blocking and errors are reported without interrupting main flows

* **Tests**
  * Added Sardine mocks and updated tests to simulate customer/risk responses

* **Chores**
  * Added runtime and test environment entries for Sardine API key and URL

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->