### PR TITLE
✅ server: use injected account factory in tests

### DIFF
--- a/.changeset/loud-apples-double.md
+++ b/.changeset/loud-apples-double.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+✅ use injected account factory in tests

--- a/server/test/api/auth.test.ts
+++ b/server/test/api/auth.test.ts
@@ -10,7 +10,7 @@ import { decodeJwt } from "jose";
 import assert from "node:assert";
 import { parse, type InferOutput } from "valibot";
 import { zeroAddress } from "viem";
-import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, describe, expect, inject, it, vi } from "vitest";
 
 import app, { type Authentication } from "../../api/auth/authentication";
 import database, { credentials } from "../../database";
@@ -25,7 +25,7 @@ describe("authentication", () => {
         id: "dGVzdC1jcmVkLWlk",
         publicKey: new Uint8Array(),
         account: zeroAddress,
-        factory: zeroAddress,
+        factory: parse(Address, inject("ExaAccountFactory")),
         counter: 0,
         transports: [],
       },
@@ -90,7 +90,7 @@ vi.mock("../../utils/redis", () => ({
 vi.mock("../../utils/createCredential", () => ({
   default: vi.fn<() => ReturnType<typeof createCredential>>().mockResolvedValue({
     credentialId: "dGVzdC1jcmVkLWlk",
-    factory: parse(Address, zeroAddress),
+    factory: parse(Address, inject("ExaAccountFactory")),
     x: "0x",
     y: "0x",
     auth: Date.now() + 1000,

--- a/server/test/api/card.test.ts
+++ b/server/test/api/card.test.ts
@@ -8,7 +8,7 @@ import { exaAccountFactoryAbi, exaPluginAbi } from "@exactly/common/generated/ch
 import { PLATINUM_PRODUCT_ID, SIGNATURE_PRODUCT_ID } from "@exactly/common/panda";
 import { eq } from "drizzle-orm";
 import { testClient } from "hono/testing";
-import { zeroHash, padHex, zeroAddress, hexToBigInt, parseEther } from "viem";
+import { zeroHash, padHex, hexToBigInt, parseEther } from "viem";
 import { privateKeyToAddress } from "viem/accounts";
 import { afterEach, beforeAll, describe, expect, inject, it, vi } from "vitest";
 
@@ -25,10 +25,28 @@ describe("authenticated", () => {
     const account = deriveAddress(inject("ExaAccountFactory"), { x: padHex(owner), y: zeroHash });
     const publicKey = new Uint8Array();
     await database.insert(credentials).values([
-      { id: "eth", publicKey, account, factory: zeroAddress, pandaId: "eth" },
-      { id: "default", publicKey, account: padHex("0x1", { size: 20 }), factory: zeroAddress, pandaId: "default" },
-      { id: "sig", publicKey, account: padHex("0x2", { size: 20 }), factory: zeroAddress, pandaId: "sig" },
-      { id: "404", publicKey, account: padHex("0x3", { size: 20 }), factory: zeroAddress, pandaId: "404" },
+      { id: "eth", publicKey, account, factory: inject("ExaAccountFactory"), pandaId: "eth" },
+      {
+        id: "default",
+        publicKey,
+        account: padHex("0x1", { size: 20 }),
+        factory: inject("ExaAccountFactory"),
+        pandaId: "default",
+      },
+      {
+        id: "sig",
+        publicKey,
+        account: padHex("0x2", { size: 20 }),
+        factory: inject("ExaAccountFactory"),
+        pandaId: "sig",
+      },
+      {
+        id: "404",
+        publicKey,
+        account: padHex("0x3", { size: 20 }),
+        factory: inject("ExaAccountFactory"),
+        pandaId: "404",
+      },
     ]);
     await database.insert(cards).values([
       { id: "default", credentialId: "default", lastFour: "1234" },
@@ -152,7 +170,7 @@ describe("authenticated", () => {
         id: foo,
         publicKey: new Uint8Array(),
         account: foo,
-        factory: zeroAddress,
+        factory: inject("ExaAccountFactory"),
       },
     ]);
     await database.insert(cards).values([{ id: `card-${foo}`, credentialId: foo, lastFour: "4567" }]);

--- a/server/test/hooks/panda.test.ts
+++ b/server/test/hooks/panda.test.ts
@@ -59,7 +59,9 @@ const account = deriveAddress(inject("ExaAccountFactory"), { x: padHex(owner.acc
 beforeAll(async () => {
   await Promise.all([
     database.transaction(async (tx) => {
-      await tx.insert(credentials).values([{ id: "cred", publicKey: new Uint8Array(), account, factory: zeroAddress }]);
+      await tx
+        .insert(credentials)
+        .values([{ id: "cred", publicKey: new Uint8Array(), account, factory: inject("ExaAccountFactory") }]);
       await tx.insert(cards).values([{ id: "card", credentialId: "cred", lastFour: "1234" }]);
     }),
     anvilClient.setBalance({ address: owner.account.address, value: 10n ** 24n }),
@@ -1236,7 +1238,9 @@ describe("concurrency", () => {
       database.transaction(async (tx) => {
         await tx
           .insert(credentials)
-          .values([{ id: account2, publicKey: new Uint8Array(), account: account2, factory: zeroAddress }]);
+          .values([
+            { id: account2, publicKey: new Uint8Array(), account: account2, factory: inject("ExaAccountFactory") },
+          ]);
         await tx.insert(cards).values([{ id: `${account2}-card`, credentialId: account2, lastFour: "1234", mode: 0 }]);
       }),
       anvilClient.setBalance({ address: owner2.account.address, value: 10n ** 24n }),

--- a/server/test/hooks/persona.test.ts
+++ b/server/test/hooks/persona.test.ts
@@ -4,8 +4,7 @@ import "../mocks/persona";
 import { captureException } from "@sentry/node";
 import { eq } from "drizzle-orm";
 import { testClient } from "hono/testing";
-import { zeroAddress } from "viem";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, inject, it, vi } from "vitest";
 
 import database, { credentials } from "../../database";
 import app from "../../hooks/persona";
@@ -54,7 +53,7 @@ describe("with reference", () => {
       id: createdAccount,
       publicKey: new Uint8Array(),
       account: createdAccount,
-      factory: zeroAddress,
+      factory: inject("ExaAccountFactory"),
       pandaId: "test-id",
     });
 

--- a/server/test/mocks/deployments.ts
+++ b/server/test/mocks/deployments.ts
@@ -5,6 +5,7 @@ vi.mock("@exactly/common/generated/chain", async (importOriginal) => ({
   ...(await importOriginal()),
   default: { ...foundry, rpcUrls: { ...foundry.rpcUrls, alchemy: foundry.rpcUrls.default } },
   auditorAddress: inject("Auditor"),
+  exaAccountFactoryAddress: inject("ExaAccountFactory"),
   exaPluginAddress: inject("ExaPlugin"),
   exaPreviewerAddress: inject("ExaPreviewer"),
   firewallAddress: inject("Firewall"),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Patch version bump for @exactly/server reflecting internal test infrastructure improvements

* **Tests**
  * Enhanced test infrastructure by migrating from hardcoded factory addresses to dependency-injected account factory references. This improves test isolation, reduces coupling between test cases, and increases maintainability across authentication, card processing, persona verification, and system hook test suites.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->