### PR TITLE
♻️ server: support multiple kyc inquiry templates

### DIFF
--- a/.changeset/common-carrots-think.md
+++ b/.changeset/common-carrots-think.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+♻️ support multiple kyc inquiry templates

--- a/.maestro/src/server.ts
+++ b/.maestro/src/server.ts
@@ -122,6 +122,17 @@ export function persona(referenceId: string, event = "approved") {
                 birthdate: { value: "1990-01-01" },
                 emailAddress: { value: "test@test.com" },
                 identificationNumber: { value: "123456789" },
+                monthlyPurchasesRange: { value: "3000" },
+                identificationClass: { value: "pp" },
+                currentGovernmentId: { value: { id: "doc_yc294YWhCZi7YKxPnoxCGMmCH111" } },
+                selectedCountryCode: { value: "TW" },
+              },
+            },
+            relationships: {
+              inquiryTemplate: {
+                data: {
+                  id: "itmpl_1igCJVqgf3xuzqKYD87HrSaDavU2",
+                },
               },
             },
           },

--- a/server/api/kyc.ts
+++ b/server/api/kyc.ts
@@ -1,10 +1,15 @@
-import { setContext, setUser } from "@sentry/node";
+import { captureException, setContext, setUser, startSpan } from "@sentry/node";
 import createDebug from "debug";
 import { eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { validator as vValidator } from "hono-openapi/valibot";
-import { literal, object, optional, parse, string } from "valibot";
+import { literal, object, optional, parse, picklist, string } from "valibot";
 
+import {
+  exaAccountFactoryAddress,
+  exaPluginAddress,
+  upgradeableModularAccountAbi,
+} from "@exactly/common/generated/chain";
 import { Address } from "@exactly/common/validation";
 
 import database, { credentials } from "../database/index";
@@ -15,85 +20,204 @@ import {
   generateOTL,
   getAccount,
   getInquiry,
+  getPendingInquiryTemplate,
   PANDA_TEMPLATE,
   resumeInquiry,
 } from "../utils/persona";
+import publicClient from "../utils/publicClient";
 import validatorHook from "../utils/validatorHook";
 
 const debug = createDebug("exa:kyc");
 Object.assign(debug, { inspectOpts: { depth: undefined } });
 
-const GetKYCQuery = object({ templateId: optional(string()), countryCode: optional(literal("true")) });
-
 export default new Hono()
-  .get("/", auth(), vValidator("query", GetKYCQuery, validatorHook()), async (c) => {
-    const templateId = c.req.valid("query").templateId ?? CRYPTOMATE_TEMPLATE;
-    if (templateId !== CRYPTOMATE_TEMPLATE && templateId !== PANDA_TEMPLATE) {
-      return c.json({ code: "bad template", legacy: "invalid persona template" }, 400);
-    }
-    const { credentialId } = c.req.valid("cookie");
-    const credential = await database.query.credentials.findFirst({
-      columns: { id: true, account: true, pandaId: true },
-      where: eq(credentials.id, credentialId),
-    });
-    if (!credential) return c.json({ code: "no credential", legacy: "no credential" }, 500);
-    if (c.req.valid("query").countryCode) {
-      const account = await getAccount(credentialId);
-      if (account?.attributes["country-code"]) c.header("User-Country", account.attributes["country-code"]);
-    }
-    setUser({ id: parse(Address, credential.account) });
-    setContext("exa", { credential });
-    if (credential.pandaId) return c.json({ code: "ok", legacy: "ok" }, 200);
-    const inquiry = await getInquiry(credentialId, templateId);
-    if (!inquiry) return c.json({ code: "no kyc", legacy: "kyc not found" }, 404);
-    if (inquiry.attributes.status === "created") {
-      return c.json({ code: "not started", legacy: "kyc not started" }, 400);
-    }
-    if (inquiry.attributes.status === "pending" || inquiry.attributes.status === "expired") {
-      const { meta } = await resumeInquiry(inquiry.id);
-      return c.json({ inquiryId: inquiry.id, sessionToken: meta["session-token"] }, 200);
-    }
-    if (inquiry.attributes.status !== "approved") {
-      return c.json({ code: "bad kyc", legacy: "kyc not approved" }, 400);
-    }
-    const account = await getAccount(credentialId);
-    if (account?.attributes["country-code"]) c.header("User-Country", account.attributes["country-code"]);
-    return c.json({ code: "ok", legacy: "ok" }, 200);
-  })
+  .get(
+    "/",
+    auth(),
+    vValidator(
+      "query",
+      object({
+        templateId: optional(picklist([CRYPTOMATE_TEMPLATE, PANDA_TEMPLATE])), // TODO remove this after deprecate templateId query parameter
+        countryCode: optional(literal("true")),
+        scope: optional(picklist(["basic"])),
+      }),
+      validatorHook(),
+    ),
+    async (c) => {
+      const templateId = c.req.valid("query").templateId;
+      const scope = c.req.valid("query").scope ?? "basic";
+
+      const { credentialId } = c.req.valid("cookie");
+      const credential = await database.query.credentials.findFirst({
+        columns: { id: true, account: true, pandaId: true, factory: true },
+        where: eq(credentials.id, credentialId),
+      });
+      if (!credential) return c.json({ code: "no credential", legacy: "no credential" }, 500);
+
+      const account = parse(Address, credential.account);
+      setUser({ id: account });
+      setContext("exa", { credential });
+
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      if (scope === "basic" && credential.pandaId) {
+        if (c.req.valid("query").countryCode) {
+          const personaAccount = await getAccount(credentialId, scope).catch((error: unknown) => {
+            captureException(error, { level: "error", contexts: { details: { credentialId, scope } } });
+          });
+          const countryCode = personaAccount?.attributes["country-code"];
+          countryCode && c.header("User-Country", countryCode);
+        }
+        return c.json({ code: "ok", legacy: "ok" }, 200);
+      }
+
+      if (templateId) {
+        const inquiry = await getInquiry(credentialId, templateId);
+        if (!inquiry) return c.json({ code: "no kyc", legacy: "kyc not found" }, 404);
+        if (inquiry.attributes.status === "created") {
+          return c.json({ code: "not started", legacy: "kyc not started" }, 400);
+        }
+        if (inquiry.attributes.status === "pending" || inquiry.attributes.status === "expired") {
+          const { meta } = await resumeInquiry(inquiry.id);
+          return c.json({ inquiryId: inquiry.id, sessionToken: meta["session-token"] }, 200);
+        }
+        if (inquiry.attributes.status !== "approved") {
+          return c.json({ code: "bad kyc", legacy: "kyc not approved" }, 400);
+        }
+        const personaAccount = await getAccount(credentialId, "basic").catch((error: unknown) => {
+          captureException(error, { level: "warning", contexts: { details: { credentialId, scope } } });
+        });
+        const countryCode = personaAccount?.attributes["country-code"];
+        countryCode && c.header("User-Country", countryCode);
+        return c.json({ code: "ok", legacy: "ok" }, 200);
+      }
+
+      if (await isLegacy(credentialId, account, credential.factory)) {
+        return c.json({ code: "legacy kyc", legacy: "legacy kyc" }, 200);
+      }
+
+      const inquiryTemplateId = await getPendingInquiryTemplate(credentialId, scope);
+      if (!inquiryTemplateId) return c.json({ code: "ok", legacy: "ok" }, 200);
+      const inquiry = await getInquiry(credentialId, inquiryTemplateId);
+      if (!inquiry) return c.json({ code: "not started", legacy: "kyc not started" }, 400);
+      switch (inquiry.attributes.status) {
+        case "approved":
+          captureException(new Error("inquiry approved but account not updated"), {
+            level: "error",
+            contexts: { inquiry: { templateId: inquiryTemplateId, referenceId: credentialId } },
+          });
+          return c.json({ code: "ok", legacy: "ok" }, 200);
+        case "created":
+        case "pending":
+        case "expired":
+          return c.json({ code: "not started", legacy: "kyc not started" }, 400);
+        case "completed":
+        case "needs_review":
+          return c.json({ code: "bad kyc", legacy: "kyc not approved" }, 400); // TODO send a different response for this transitory statuses
+        case "failed":
+        case "declined":
+          return c.json({ code: "bad kyc", legacy: "kyc not approved" }, 400);
+        default:
+          throw new Error("Unknown inquiry status");
+      }
+    },
+  )
   .post(
     "/",
     auth(),
     vValidator(
       "json",
-      object({ templateId: optional(string()), redirectURI: optional(string()) }),
+      object({
+        redirectURI: optional(string()),
+        scope: optional(picklist(["basic"])),
+        templateId: optional(string()), // TODO remove this after deprecate templateId query parameter
+      }),
       validatorHook({ debug }),
     ),
     async (c) => {
-      const payload = c.req.valid("json");
       const { credentialId } = c.req.valid("cookie");
-      const templateId = payload.templateId ?? CRYPTOMATE_TEMPLATE;
+      const payload = c.req.valid("json");
+      const scope = payload.scope ?? "basic";
       const redirectURI = payload.redirectURI;
       const credential = await database.query.credentials.findFirst({
         columns: { id: true, account: true, pandaId: true },
         where: eq(credentials.id, credentialId),
       });
       if (!credential) return c.json({ code: "no credential", legacy: "no credential" }, 500);
-      if (credential.pandaId) return c.json({ code: "already approved", legacy: "kyc already approved" }, 400);
       setUser({ id: parse(Address, credential.account) });
       setContext("exa", { credential });
-      const inquiry = await getInquiry(credentialId, templateId);
-      if (inquiry) {
-        if (inquiry.attributes.status === "approved") {
-          return c.json({ code: "already approved", legacy: "kyc already approved" }, 400);
-        }
-        if (inquiry.attributes.status === "created" || inquiry.attributes.status === "expired") {
-          const { meta } = await generateOTL(inquiry.id);
-          return c.json({ otl: meta["one-time-link"], legacy: meta["one-time-link"] }, 200);
-        }
-        return c.json({ code: "failed", legacy: "kyc failed" }, 400);
+
+      const inquiryTemplateId = await getPendingInquiryTemplate(credentialId, scope);
+      if (!inquiryTemplateId) {
+        return c.json({ code: "already approved", legacy: "kyc already approved" }, 400);
       }
-      const { data } = await createInquiry(credentialId, redirectURI);
-      const { meta } = await generateOTL(data.id);
-      return c.json({ otl: meta["one-time-link"], legacy: meta["one-time-link"] }, 200);
+
+      const inquiry = await getInquiry(credentialId, inquiryTemplateId);
+      if (!inquiry) {
+        const { data } = await createInquiry(credentialId, inquiryTemplateId, redirectURI);
+        // TODO use a query param to select otl or sessionToken
+        const { inquiryId, otl, sessionToken, legacy } = await generateInquiryTokens(data.id);
+        return c.json({ inquiryId, otl, sessionToken, legacy }, 200);
+      }
+
+      switch (inquiry.attributes.status) {
+        case "approved":
+          captureException(new Error("inquiry approved but account not updated"), {
+            level: "error",
+            contexts: { inquiry: { templateId: inquiryTemplateId, referenceId: credentialId } },
+          });
+          return c.json({ code: "already approved", legacy: "kyc already approved" }, 400);
+        case "failed":
+        case "declined":
+          return c.json({ code: "failed", legacy: "kyc failed" }, 400);
+        case "completed":
+        case "needs_review":
+          return c.json({ code: "failed", legacy: "kyc failed" }, 400); // TODO send a different response
+        case "pending":
+        case "created":
+        case "expired": {
+          // TODO use a query param to select otl or sessionToken
+          const { inquiryId, otl, sessionToken, legacy } = await generateInquiryTokens(inquiry.id);
+          return c.json({ inquiryId, otl, sessionToken, legacy }, 200);
+        }
+        default:
+          throw new Error("Unknown inquiry status");
+      }
     },
   );
+
+async function isLegacy(credentialId: string, account: Address, factory: string): Promise<boolean> {
+  if (factory === exaAccountFactoryAddress) return false;
+  return await startSpan({ name: "exa.kyc", op: "isLegacy" }, async () => {
+    const installedPlugin = await publicClient.readContract({
+      address: account,
+      functionName: "getInstalledPlugins",
+      abi: upgradeableModularAccountAbi,
+    });
+    if (installedPlugin.length === 0) return false;
+    if (installedPlugin.includes(exaPluginAddress)) return false;
+    const [legacyKyc, inquiry] = await Promise.all([
+      getInquiry(credentialId, CRYPTOMATE_TEMPLATE),
+      getInquiry(credentialId, PANDA_TEMPLATE),
+    ]);
+
+    return legacyKyc?.attributes.status === "approved" && !inquiry;
+  });
+}
+
+async function generateInquiryTokens(inquiryId: string): Promise<{
+  inquiryId: string;
+  legacy: string;
+  otl: string;
+  sessionToken: string;
+}> {
+  const [{ meta: otlMeta }, { meta: sessionTokenMeta }] = await Promise.all([
+    generateOTL(inquiryId),
+    resumeInquiry(inquiryId),
+  ]);
+  return {
+    inquiryId,
+    legacy: otlMeta["one-time-link"],
+    otl: otlMeta["one-time-link"],
+    sessionToken: sessionTokenMeta["session-token"],
+  };
+}

--- a/server/test/api/kyc.test.ts
+++ b/server/test/api/kyc.test.ts
@@ -2,162 +2,1054 @@ import "../mocks/auth";
 import "../mocks/deployments";
 import "../mocks/sentry";
 
+import { captureException } from "@sentry/node";
 import { eq } from "drizzle-orm";
 import { testClient } from "hono/testing";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, inject, it, vi } from "vitest";
 
 import app from "../../api/kyc";
 import database, { credentials } from "../../database";
 import * as persona from "../../utils/persona";
+import publicClient from "../../utils/publicClient";
 
 const appClient = testClient(app);
 
+vi.mock("@sentry/node", { spy: true });
+
 describe("authenticated", () => {
+  beforeEach(async () => {
+    await database.update(credentials).set({ pandaId: null }).where(eq(credentials.id, "bob"));
+  });
+
   afterEach(() => vi.restoreAllMocks());
 
-  it("returns ok kyc approved with country code", async () => {
-    await database.update(credentials).set({ pandaId: "pandaId" }).where(eq(credentials.id, "bob"));
-    const getInquiry = vi.spyOn(persona, "getInquiry");
-    const getAccount = vi.spyOn(persona, "getAccount").mockResolvedValueOnce({
-      ...personaTemplate,
-      type: "account",
-      attributes: {
-        "country-code": "AR",
-        "social-security-number": null,
-        "address-street-1": "123 Main St",
-        "address-street-2": null,
-        "address-city": "New York",
-        "address-subdivision": null,
-        "address-postal-code": "10001",
-        fields: {},
-      },
+  describe("basic scope", () => {
+    describe("getting kyc", () => {
+      it("is the default scope", async () => {
+        await database.update(credentials).set({ pandaId: null }).where(eq(credentials.id, "bob"));
+        vi.spyOn(persona, "getInquiry").mockResolvedValueOnce(undefined); // eslint-disable-line unicorn/no-useless-undefined
+        const getPendingInquiryTemplate = vi
+          .spyOn(persona, "getPendingInquiryTemplate")
+          .mockResolvedValueOnce(undefined); // eslint-disable-line unicorn/no-useless-undefined
+
+        await appClient.index.$get({ query: {} }, { headers: { "test-credential-id": "bob" } });
+
+        expect(getPendingInquiryTemplate).toHaveBeenCalledWith("bob", "basic");
+      });
+
+      it("returns ok kyc approved with country code when panda id is present", async () => {
+        await database.update(credentials).set({ pandaId: "pandaId" }).where(eq(credentials.id, "bob"));
+        const getInquiry = vi.spyOn(persona, "getInquiry");
+        const getAccount = vi
+          .spyOn(persona, "getAccount")
+          .mockResolvedValueOnce(basicAccount as persona.AccountOutput<"basic">);
+
+        const response = await appClient.index.$get(
+          { query: { countryCode: "true", scope: "basic" } },
+          { headers: { "test-credential-id": "bob", SessionID: "fakeSession" } },
+        );
+
+        expect(getAccount).toHaveBeenCalledOnce();
+        expect(getInquiry).not.toHaveBeenCalled();
+        await expect(response.json()).resolves.toStrictEqual({ code: "ok", legacy: "ok" });
+        expect(response.headers.get("User-Country")).toBe("AR");
+        expect(response.status).toBe(200);
+      });
+
+      it("returns ok code when account has all fields", async () => {
+        await database.update(credentials).set({ pandaId: null }).where(eq(credentials.id, "bob"));
+        const getPendingInquiryTemplate = vi
+          .spyOn(persona, "getPendingInquiryTemplate")
+          .mockResolvedValueOnce(undefined); // eslint-disable-line unicorn/no-useless-undefined
+
+        const response = await appClient.index.$get(
+          { query: { scope: "basic" } },
+          { headers: { "test-credential-id": "bob", SessionID: "fakeSession" } },
+        );
+
+        expect(getPendingInquiryTemplate).toHaveBeenCalledWith("bob", "basic");
+        await expect(response.json()).resolves.toStrictEqual({ code: "ok", legacy: "ok" });
+        expect(response.status).toBe(200);
+      });
+
+      it("returns not started when inquiry is not found", async () => {
+        await database.update(credentials).set({ pandaId: null }).where(eq(credentials.id, "bob"));
+        const getPendingInquiryTemplate = vi
+          .spyOn(persona, "getPendingInquiryTemplate")
+          .mockResolvedValueOnce(persona.PANDA_TEMPLATE);
+        const getInquiry = vi.spyOn(persona, "getInquiry").mockResolvedValueOnce(undefined); // eslint-disable-line unicorn/no-useless-undefined
+
+        const response = await appClient.index.$get(
+          { query: { scope: "basic" } },
+          { headers: { "test-credential-id": "bob" } },
+        );
+
+        expect(getPendingInquiryTemplate).toHaveBeenCalledWith("bob", "basic");
+        expect(getInquiry).toHaveBeenCalledWith("bob", persona.PANDA_TEMPLATE);
+        await expect(response.json()).resolves.toStrictEqual({ code: "not started", legacy: "kyc not started" });
+        expect(response.status).toBe(400);
+      });
+
+      it("returns ok and sends sentry error if template is required but inquiry is approved", async () => {
+        await database.update(credentials).set({ pandaId: null }).where(eq(credentials.id, "bob"));
+        const getPendingInquiryTemplate = vi
+          .spyOn(persona, "getPendingInquiryTemplate")
+          .mockResolvedValueOnce(persona.PANDA_TEMPLATE);
+        const getInquiry = vi.spyOn(persona, "getInquiry").mockResolvedValueOnce({
+          ...personaTemplate,
+          attributes: { ...personaTemplate.attributes, status: "approved" },
+        });
+
+        const response = await appClient.index.$get(
+          { query: { scope: "basic" } },
+          { headers: { "test-credential-id": "bob" } },
+        );
+
+        expect(getPendingInquiryTemplate).toHaveBeenCalledWith("bob", "basic");
+        expect(getInquiry).toHaveBeenCalledWith("bob", persona.PANDA_TEMPLATE);
+        await expect(response.json()).resolves.toStrictEqual({ code: "ok", legacy: "ok" });
+        expect(response.status).toBe(200);
+        expect(captureException).toHaveBeenCalledWith(new Error("inquiry approved but account not updated"), {
+          level: "error",
+          contexts: { inquiry: { templateId: persona.PANDA_TEMPLATE, referenceId: "bob" } },
+        });
+      });
+
+      it("returns not started when inquiry is created", async () => {
+        await database.update(credentials).set({ pandaId: null }).where(eq(credentials.id, "bob"));
+        const getPendingInquiryTemplate = vi
+          .spyOn(persona, "getPendingInquiryTemplate")
+          .mockResolvedValueOnce(persona.PANDA_TEMPLATE);
+        const getInquiry = vi.spyOn(persona, "getInquiry").mockResolvedValueOnce({
+          ...personaTemplate,
+          attributes: { ...personaTemplate.attributes, status: "created" },
+        });
+
+        const response = await appClient.index.$get(
+          { query: { scope: "basic" } },
+          { headers: { "test-credential-id": "bob" } },
+        );
+
+        expect(getPendingInquiryTemplate).toHaveBeenCalledWith("bob", "basic");
+        expect(getInquiry).toHaveBeenCalledWith("bob", persona.PANDA_TEMPLATE);
+        await expect(response.json()).resolves.toStrictEqual({ code: "not started", legacy: "kyc not started" });
+        expect(response.status).toBe(400);
+      });
+
+      it("returns not started when inquiry is pending", async () => {
+        await database.update(credentials).set({ pandaId: null }).where(eq(credentials.id, "bob"));
+        const getPendingInquiryTemplate = vi
+          .spyOn(persona, "getPendingInquiryTemplate")
+          .mockResolvedValueOnce(persona.PANDA_TEMPLATE);
+        const getInquiry = vi.spyOn(persona, "getInquiry").mockResolvedValueOnce({
+          ...personaTemplate,
+          attributes: { ...personaTemplate.attributes, status: "pending" },
+        });
+
+        const response = await appClient.index.$get(
+          { query: { scope: "basic" } },
+          { headers: { "test-credential-id": "bob" } },
+        );
+
+        expect(getPendingInquiryTemplate).toHaveBeenCalledWith("bob", "basic");
+        expect(getInquiry).toHaveBeenCalledWith("bob", persona.PANDA_TEMPLATE);
+        await expect(response.json()).resolves.toStrictEqual({ code: "not started", legacy: "kyc not started" });
+        expect(response.status).toBe(400);
+      });
+
+      it("returns not started when inquiry is expired", async () => {
+        await database.update(credentials).set({ pandaId: null }).where(eq(credentials.id, "bob"));
+        const getPendingInquiryTemplate = vi
+          .spyOn(persona, "getPendingInquiryTemplate")
+          .mockResolvedValueOnce(persona.PANDA_TEMPLATE);
+        const getInquiry = vi.spyOn(persona, "getInquiry").mockResolvedValueOnce({
+          ...personaTemplate,
+          attributes: { ...personaTemplate.attributes, status: "expired" },
+        });
+
+        const response = await appClient.index.$get(
+          { query: { scope: "basic" } },
+          { headers: { "test-credential-id": "bob" } },
+        );
+
+        expect(getPendingInquiryTemplate).toHaveBeenCalledWith("bob", "basic");
+        expect(getInquiry).toHaveBeenCalledWith("bob", persona.PANDA_TEMPLATE);
+        await expect(response.json()).resolves.toStrictEqual({ code: "not started", legacy: "kyc not started" });
+        expect(response.status).toBe(400);
+      });
+
+      it("returns bad kyc when inquiry is completed", async () => {
+        await database.update(credentials).set({ pandaId: null }).where(eq(credentials.id, "bob"));
+        const getPendingInquiryTemplate = vi
+          .spyOn(persona, "getPendingInquiryTemplate")
+          .mockResolvedValueOnce(persona.PANDA_TEMPLATE);
+        const getInquiry = vi.spyOn(persona, "getInquiry").mockResolvedValueOnce({
+          ...personaTemplate,
+          attributes: { ...personaTemplate.attributes, status: "completed" },
+        });
+
+        const response = await appClient.index.$get(
+          { query: { scope: "basic" } },
+          { headers: { "test-credential-id": "bob" } },
+        );
+
+        expect(getPendingInquiryTemplate).toHaveBeenCalledWith("bob", "basic");
+        expect(getInquiry).toHaveBeenCalledWith("bob", persona.PANDA_TEMPLATE);
+        await expect(response.json()).resolves.toStrictEqual({ code: "bad kyc", legacy: "kyc not approved" });
+        expect(response.status).toBe(400);
+      });
+
+      it("returns bad kyc when inquiry needs review", async () => {
+        await database.update(credentials).set({ pandaId: null }).where(eq(credentials.id, "bob"));
+        const getPendingInquiryTemplate = vi
+          .spyOn(persona, "getPendingInquiryTemplate")
+          .mockResolvedValueOnce(persona.PANDA_TEMPLATE);
+        const getInquiry = vi.spyOn(persona, "getInquiry").mockResolvedValueOnce({
+          ...personaTemplate,
+          attributes: { ...personaTemplate.attributes, status: "needs_review" },
+        });
+
+        const response = await appClient.index.$get(
+          { query: { scope: "basic" } },
+          { headers: { "test-credential-id": "bob" } },
+        );
+
+        expect(getPendingInquiryTemplate).toHaveBeenCalledWith("bob", "basic");
+        expect(getInquiry).toHaveBeenCalledWith("bob", persona.PANDA_TEMPLATE);
+        await expect(response.json()).resolves.toStrictEqual({ code: "bad kyc", legacy: "kyc not approved" });
+        expect(response.status).toBe(400);
+      });
+
+      it("returns bad kyc when inquiry failed", async () => {
+        await database.update(credentials).set({ pandaId: null }).where(eq(credentials.id, "bob"));
+        const getPendingInquiryTemplate = vi
+          .spyOn(persona, "getPendingInquiryTemplate")
+          .mockResolvedValueOnce(persona.PANDA_TEMPLATE);
+        const getInquiry = vi.spyOn(persona, "getInquiry").mockResolvedValueOnce({
+          ...personaTemplate,
+          attributes: { ...personaTemplate.attributes, status: "failed" },
+        });
+
+        const response = await appClient.index.$get(
+          { query: { scope: "basic" } },
+          { headers: { "test-credential-id": "bob" } },
+        );
+
+        expect(getPendingInquiryTemplate).toHaveBeenCalledWith("bob", "basic");
+        expect(getInquiry).toHaveBeenCalledWith("bob", persona.PANDA_TEMPLATE);
+        await expect(response.json()).resolves.toStrictEqual({ code: "bad kyc", legacy: "kyc not approved" });
+        expect(response.status).toBe(400);
+      });
     });
 
-    const response = await appClient.index.$get(
-      { query: { countryCode: "true" } },
-      { headers: { "test-credential-id": "bob", SessionID: "fakeSession" } },
-    );
+    describe("posting kyc", () => {
+      it("is the default scope", async () => {
+        await database.update(credentials).set({ pandaId: null }).where(eq(credentials.id, "bob"));
+        vi.spyOn(persona, "getInquiry").mockResolvedValueOnce(undefined); // eslint-disable-line unicorn/no-useless-undefined
+        const getPendingInquiryTemplate = vi
+          .spyOn(persona, "getPendingInquiryTemplate")
+          .mockResolvedValueOnce(undefined); // eslint-disable-line unicorn/no-useless-undefined
 
-    expect(getAccount).toHaveBeenCalledOnce();
-    expect(getInquiry).not.toHaveBeenCalled();
-    await expect(response.json()).resolves.toStrictEqual({ code: "ok", legacy: "ok" });
-    expect(response.headers.get("User-Country")).toBe("AR");
-    expect(response.status).toBe(200);
+        await appClient.index.$post(
+          { json: {} },
+          { headers: { "test-credential-id": "bob", SessionID: "fakeSession" } },
+        );
+
+        expect(getPendingInquiryTemplate).toHaveBeenCalledWith("bob", "basic");
+      });
+
+      it("returns already approved when account has all fields", async () => {
+        await database.update(credentials).set({ pandaId: "pandaId" }).where(eq(credentials.id, "bob"));
+        const getPendingInquiryTemplate = vi
+          .spyOn(persona, "getPendingInquiryTemplate")
+          .mockResolvedValueOnce(undefined); // eslint-disable-line unicorn/no-useless-undefined
+
+        const response = await appClient.index.$post(
+          { json: { scope: "basic" } },
+          { headers: { "test-credential-id": "bob" } },
+        );
+
+        expect(getPendingInquiryTemplate).toHaveBeenCalledWith("bob", "basic");
+        await expect(response.json()).resolves.toStrictEqual({
+          code: "already approved",
+          legacy: "kyc already approved",
+        });
+        expect(response.status).toBe(400);
+      });
+
+      it("returns already approved and sends sentry error when template is required but inquiry is approved", async () => {
+        await database.update(credentials).set({ pandaId: "pandaId" }).where(eq(credentials.id, "bob"));
+        const getPendingInquiryTemplate = vi
+          .spyOn(persona, "getPendingInquiryTemplate")
+          .mockResolvedValueOnce(persona.PANDA_TEMPLATE);
+        vi.spyOn(persona, "getInquiry").mockResolvedValueOnce({
+          ...personaTemplate,
+          attributes: { ...personaTemplate.attributes, status: "approved" },
+        });
+
+        const response = await appClient.index.$post(
+          { json: { scope: "basic" } },
+          { headers: { "test-credential-id": "bob" } },
+        );
+
+        expect(getPendingInquiryTemplate).toHaveBeenCalledWith("bob", "basic");
+        await expect(response.json()).resolves.toStrictEqual({
+          code: "already approved",
+          legacy: "kyc already approved",
+        });
+        expect(response.status).toBe(400);
+        expect(captureException).toHaveBeenCalledWith(new Error("inquiry approved but account not updated"), {
+          level: "error",
+          contexts: { inquiry: { templateId: persona.PANDA_TEMPLATE, referenceId: "bob" } },
+        });
+      });
+
+      it("returns OTL and session token when creating inquiry", async () => {
+        await database.update(credentials).set({ pandaId: null }).where(eq(credentials.id, "bob"));
+
+        const otl = "https://new-url.com";
+        const sessionToken = "persona-session-token";
+
+        vi.spyOn(persona, "getInquiry").mockResolvedValueOnce(undefined); // eslint-disable-line unicorn/no-useless-undefined
+        vi.spyOn(persona, "generateOTL").mockResolvedValueOnce({
+          ...OTLTemplate,
+          meta: { ...OTLTemplate.meta, "one-time-link": otl },
+        });
+        vi.spyOn(persona, "resumeInquiry").mockResolvedValueOnce({
+          ...resumeTemplate,
+          meta: { ...resumeTemplate.meta, "session-token": sessionToken },
+        });
+
+        const getPendingInquiryTemplate = vi
+          .spyOn(persona, "getPendingInquiryTemplate")
+          .mockResolvedValueOnce(persona.PANDA_TEMPLATE);
+        const createInquiry = vi.spyOn(persona, "createInquiry").mockResolvedValueOnce(inquiry);
+
+        const response = await appClient.index.$post(
+          { json: { scope: "basic" } },
+          { headers: { "test-credential-id": "bob" } },
+        );
+
+        expect(getPendingInquiryTemplate).toHaveBeenCalledWith("bob", "basic");
+        expect(createInquiry).toHaveBeenCalledWith("bob", persona.PANDA_TEMPLATE, undefined);
+        await expect(response.json()).resolves.toStrictEqual({
+          otl,
+          sessionToken,
+          legacy: otl,
+          inquiryId: resumeTemplate.data.id,
+        });
+        expect(response.status).toBe(200);
+      });
+
+      it("returns OTL link and session token when resuming created inquiry", async () => {
+        const otl = "https://resume-url.com";
+        const sessionToken = "persona-session-token";
+
+        vi.spyOn(persona, "generateOTL").mockResolvedValueOnce({
+          ...OTLTemplate,
+          meta: { ...OTLTemplate.meta, "one-time-link": otl },
+        });
+        vi.spyOn(persona, "resumeInquiry").mockResolvedValueOnce({
+          ...resumeTemplate,
+          meta: { ...resumeTemplate.meta, "session-token": sessionToken },
+        });
+        const getPendingInquiryTemplate = vi
+          .spyOn(persona, "getPendingInquiryTemplate")
+          .mockResolvedValueOnce(persona.PANDA_TEMPLATE);
+        const getInquiry = vi.spyOn(persona, "getInquiry").mockResolvedValueOnce({
+          ...personaTemplate,
+          attributes: { ...personaTemplate.attributes, status: "created" },
+        });
+        const response = await appClient.index.$post(
+          { json: { scope: "basic" } },
+          { headers: { "test-credential-id": "bob" } },
+        );
+
+        expect(getPendingInquiryTemplate).toHaveBeenCalledWith("bob", "basic");
+        expect(getInquiry).toHaveBeenCalledWith("bob", persona.PANDA_TEMPLATE);
+        await expect(response.json()).resolves.toStrictEqual({
+          otl,
+          sessionToken,
+          legacy: otl,
+          inquiryId: resumeTemplate.data.id,
+        });
+        expect(response.status).toBe(200);
+      });
+
+      it("returns OTL link and session token when resuming pending inquiry", async () => {
+        const otl = "https://resume-url.com";
+        const sessionToken = "persona-session-token";
+
+        vi.spyOn(persona, "generateOTL").mockResolvedValueOnce({
+          ...OTLTemplate,
+          meta: { ...OTLTemplate.meta, "one-time-link": otl },
+        });
+        vi.spyOn(persona, "resumeInquiry").mockResolvedValueOnce({
+          ...resumeTemplate,
+          meta: { ...resumeTemplate.meta, "session-token": sessionToken },
+        });
+        const getPendingInquiryTemplate = vi
+          .spyOn(persona, "getPendingInquiryTemplate")
+          .mockResolvedValueOnce(persona.PANDA_TEMPLATE);
+        const getInquiry = vi.spyOn(persona, "getInquiry").mockResolvedValueOnce({
+          ...personaTemplate,
+          attributes: { ...personaTemplate.attributes, status: "pending" },
+        });
+        const response = await appClient.index.$post(
+          { json: { scope: "basic" } },
+          { headers: { "test-credential-id": "bob" } },
+        );
+
+        expect(getPendingInquiryTemplate).toHaveBeenCalledWith("bob", "basic");
+        expect(getInquiry).toHaveBeenCalledWith("bob", persona.PANDA_TEMPLATE);
+        await expect(response.json()).resolves.toStrictEqual({
+          otl,
+          sessionToken,
+          legacy: otl,
+          inquiryId: resumeTemplate.data.id,
+        });
+        expect(response.status).toBe(200);
+      });
+
+      it("returns OTL link and session token when resuming expired inquiry", async () => {
+        const otl = "https://resume-url.com";
+        const sessionToken = "persona-session-token";
+
+        vi.spyOn(persona, "generateOTL").mockResolvedValueOnce({
+          ...OTLTemplate,
+          meta: { ...OTLTemplate.meta, "one-time-link": otl },
+        });
+        vi.spyOn(persona, "resumeInquiry").mockResolvedValueOnce({
+          ...resumeTemplate,
+          meta: { ...resumeTemplate.meta, "session-token": sessionToken },
+        });
+        const getPendingInquiryTemplate = vi
+          .spyOn(persona, "getPendingInquiryTemplate")
+          .mockResolvedValueOnce(persona.PANDA_TEMPLATE);
+        const getInquiry = vi.spyOn(persona, "getInquiry").mockResolvedValueOnce({
+          ...personaTemplate,
+          attributes: { ...personaTemplate.attributes, status: "expired" },
+        });
+        const response = await appClient.index.$post(
+          { json: { scope: "basic" } },
+          { headers: { "test-credential-id": "bob" } },
+        );
+
+        expect(getPendingInquiryTemplate).toHaveBeenCalledWith("bob", "basic");
+        expect(getInquiry).toHaveBeenCalledWith("bob", persona.PANDA_TEMPLATE);
+        await expect(response.json()).resolves.toStrictEqual({
+          otl,
+          sessionToken,
+          legacy: otl,
+          inquiryId: resumeTemplate.data.id,
+        });
+        expect(response.status).toBe(200);
+      });
+
+      it("returns failed kyc when inquiry failed", async () => {
+        const getPendingInquiryTemplate = vi
+          .spyOn(persona, "getPendingInquiryTemplate")
+          .mockResolvedValueOnce(persona.PANDA_TEMPLATE);
+        const getInquiry = vi.spyOn(persona, "getInquiry").mockResolvedValueOnce({
+          ...personaTemplate,
+          attributes: { ...personaTemplate.attributes, status: "failed" },
+        });
+
+        const response = await appClient.index.$post(
+          { json: { scope: "basic" } },
+          { headers: { "test-credential-id": "bob" } },
+        );
+
+        expect(getPendingInquiryTemplate).toHaveBeenCalledWith("bob", "basic");
+        expect(getInquiry).toHaveBeenCalledWith("bob", persona.PANDA_TEMPLATE);
+        await expect(response.json()).resolves.toStrictEqual({ code: "failed", legacy: "kyc failed" });
+        expect(response.status).toBe(400);
+      });
+
+      it("returns failed kyc when inquiry is declined", async () => {
+        const getPendingInquiryTemplate = vi
+          .spyOn(persona, "getPendingInquiryTemplate")
+          .mockResolvedValueOnce(persona.PANDA_TEMPLATE);
+        const getInquiry = vi.spyOn(persona, "getInquiry").mockResolvedValueOnce({
+          ...personaTemplate,
+          attributes: { ...personaTemplate.attributes, status: "declined" },
+        });
+
+        const response = await appClient.index.$post(
+          { json: { scope: "basic" } },
+          { headers: { "test-credential-id": "bob" } },
+        );
+
+        expect(getPendingInquiryTemplate).toHaveBeenCalledWith("bob", "basic");
+        expect(getInquiry).toHaveBeenCalledWith("bob", persona.PANDA_TEMPLATE);
+        await expect(response.json()).resolves.toStrictEqual({ code: "failed", legacy: "kyc failed" });
+        expect(response.status).toBe(400);
+      });
+
+      it("returns failed kyc when inquiry is completed", async () => {
+        const getPendingInquiryTemplate = vi
+          .spyOn(persona, "getPendingInquiryTemplate")
+          .mockResolvedValueOnce(persona.PANDA_TEMPLATE);
+        const getInquiry = vi.spyOn(persona, "getInquiry").mockResolvedValueOnce({
+          ...personaTemplate,
+          attributes: { ...personaTemplate.attributes, status: "completed" },
+        });
+
+        const response = await appClient.index.$post(
+          { json: { scope: "basic" } },
+          { headers: { "test-credential-id": "bob" } },
+        );
+
+        expect(getPendingInquiryTemplate).toHaveBeenCalledWith("bob", "basic");
+        expect(getInquiry).toHaveBeenCalledWith("bob", persona.PANDA_TEMPLATE);
+        await expect(response.json()).resolves.toStrictEqual({ code: "failed", legacy: "kyc failed" });
+        expect(response.status).toBe(400);
+      });
+
+      it("returns failed kyc when inquiry needs review", async () => {
+        const getPendingInquiryTemplate = vi
+          .spyOn(persona, "getPendingInquiryTemplate")
+          .mockResolvedValueOnce(persona.PANDA_TEMPLATE);
+        const getInquiry = vi.spyOn(persona, "getInquiry").mockResolvedValueOnce({
+          ...personaTemplate,
+          attributes: { ...personaTemplate.attributes, status: "needs_review" },
+        });
+        const response = await appClient.index.$post(
+          { json: { scope: "basic" } },
+          { headers: { "test-credential-id": "bob" } },
+        );
+
+        expect(getPendingInquiryTemplate).toHaveBeenCalledWith("bob", "basic");
+        expect(getInquiry).toHaveBeenCalledWith("bob", persona.PANDA_TEMPLATE);
+        await expect(response.json()).resolves.toStrictEqual({ code: "failed", legacy: "kyc failed" });
+        expect(response.status).toBe(400);
+      });
+    });
   });
 
-  it("returns ok kyc approved when panda id is present", async () => {
-    await database.update(credentials).set({ pandaId: "pandaId" }).where(eq(credentials.id, "bob"));
-    const getInquiry = vi.spyOn(persona, "getInquiry");
-    const getAccount = vi.spyOn(persona, "getAccount");
+  describe("isLegacy flow", () => {
+    const legacyFactory = "0x0000000000000000000000000000000000001234";
+    const legacyPlugin = "0x0000000000000000000000000000000000005678";
 
-    const response = await appClient.index.$get(
-      { query: {} },
-      { headers: { "test-credential-id": "bob", SessionID: "fakeSession" } },
-    );
+    beforeEach(async () => {
+      await database.update(credentials).set({ pandaId: null }).where(eq(credentials.id, "bob"));
+    });
 
-    expect(getAccount).not.toHaveBeenCalled();
-    expect(getInquiry).not.toHaveBeenCalled();
-    await expect(response.json()).resolves.toStrictEqual({ code: "ok", legacy: "ok" });
-    expect(response.status).toBe(200);
+    afterEach(() => vi.restoreAllMocks());
+
+    it("skips legacy check when factory is current exaAccountFactory", async () => {
+      await database
+        .update(credentials)
+        .set({ pandaId: null, factory: inject("ExaAccountFactory") })
+        .where(eq(credentials.id, "bob"));
+      const readContract = vi.spyOn(publicClient, "readContract");
+      const getPendingInquiryTemplate = vi.spyOn(persona, "getPendingInquiryTemplate").mockResolvedValueOnce(undefined); // eslint-disable-line unicorn/no-useless-undefined
+
+      const response = await appClient.index.$get(
+        { query: { scope: "basic" } },
+        { headers: { "test-credential-id": "bob" } },
+      );
+
+      expect(readContract).not.toHaveBeenCalled();
+      expect(getPendingInquiryTemplate).toHaveBeenCalledWith("bob", "basic");
+      await expect(response.json()).resolves.toStrictEqual({ code: "ok", legacy: "ok" });
+      expect(response.status).toBe(200);
+    });
+
+    it("returns not legacy when no plugins installed", async () => {
+      await database
+        .update(credentials)
+        .set({ pandaId: null, factory: legacyFactory })
+        .where(eq(credentials.id, "bob"));
+      const readContract = vi.spyOn(publicClient, "readContract").mockResolvedValueOnce([]);
+      const getPendingInquiryTemplate = vi.spyOn(persona, "getPendingInquiryTemplate").mockResolvedValueOnce(undefined); // eslint-disable-line unicorn/no-useless-undefined
+
+      const response = await appClient.index.$get(
+        { query: { scope: "basic" } },
+        { headers: { "test-credential-id": "bob" } },
+      );
+
+      expect(readContract).toHaveBeenCalledOnce();
+      expect(getPendingInquiryTemplate).toHaveBeenCalledWith("bob", "basic");
+      await expect(response.json()).resolves.toStrictEqual({ code: "ok", legacy: "ok" });
+      expect(response.status).toBe(200);
+    });
+
+    it("returns not legacy when latest plugin is installed", async () => {
+      await database
+        .update(credentials)
+        .set({ pandaId: null, factory: legacyFactory })
+        .where(eq(credentials.id, "bob"));
+      const readContract = vi.spyOn(publicClient, "readContract").mockResolvedValueOnce([inject("ExaPlugin")]);
+      const getPendingInquiryTemplate = vi.spyOn(persona, "getPendingInquiryTemplate").mockResolvedValueOnce(undefined); // eslint-disable-line unicorn/no-useless-undefined
+
+      const response = await appClient.index.$get(
+        { query: { scope: "basic" } },
+        { headers: { "test-credential-id": "bob" } },
+      );
+
+      expect(readContract).toHaveBeenCalledOnce();
+      expect(getPendingInquiryTemplate).toHaveBeenCalledWith("bob", "basic");
+      await expect(response.json()).resolves.toStrictEqual({ code: "ok", legacy: "ok" });
+      expect(response.status).toBe(200);
+    });
+
+    it("returns legacy kyc when old plugin with approved cryptomate and no panda inquiry", async () => {
+      await database
+        .update(credentials)
+        .set({ pandaId: null, factory: legacyFactory })
+        .where(eq(credentials.id, "bob"));
+      vi.spyOn(publicClient, "readContract").mockResolvedValueOnce([legacyPlugin]);
+      const getInquiry = vi.spyOn(persona, "getInquiry");
+      getInquiry.mockImplementation((_credentialId, templateId) => {
+        if (templateId === persona.CRYPTOMATE_TEMPLATE) {
+          return Promise.resolve({
+            ...personaTemplate,
+            attributes: { ...personaTemplate.attributes, status: "approved" },
+          });
+        }
+        return Promise.resolve(undefined); // eslint-disable-line unicorn/no-useless-undefined
+      });
+
+      const response = await appClient.index.$get(
+        { query: { scope: "basic" } },
+        { headers: { "test-credential-id": "bob" } },
+      );
+
+      expect(getInquiry).toHaveBeenCalledWith("bob", persona.CRYPTOMATE_TEMPLATE);
+      expect(getInquiry).toHaveBeenCalledWith("bob", persona.PANDA_TEMPLATE);
+      await expect(response.json()).resolves.toStrictEqual({ code: "legacy kyc", legacy: "legacy kyc" });
+      expect(response.status).toBe(200);
+    });
+
+    it("returns not legacy when old plugin with approved cryptomate but panda inquiry exists", async () => {
+      await database
+        .update(credentials)
+        .set({ pandaId: null, factory: legacyFactory })
+        .where(eq(credentials.id, "bob"));
+      vi.spyOn(publicClient, "readContract").mockResolvedValueOnce([legacyPlugin]);
+      const getInquiry = vi.spyOn(persona, "getInquiry");
+      getInquiry.mockImplementation((_credentialId, templateId) => {
+        if (templateId === persona.CRYPTOMATE_TEMPLATE) {
+          return Promise.resolve({
+            ...personaTemplate,
+            attributes: { ...personaTemplate.attributes, status: "approved" },
+          });
+        }
+        return Promise.resolve({
+          ...personaTemplate,
+          attributes: { ...personaTemplate.attributes, status: "pending" },
+        });
+      });
+      const getPendingInquiryTemplate = vi
+        .spyOn(persona, "getPendingInquiryTemplate")
+        .mockResolvedValueOnce(persona.PANDA_TEMPLATE);
+
+      const response = await appClient.index.$get(
+        { query: { scope: "basic" } },
+        { headers: { "test-credential-id": "bob" } },
+      );
+
+      expect(getInquiry).toHaveBeenCalledWith("bob", persona.CRYPTOMATE_TEMPLATE);
+      expect(getInquiry).toHaveBeenCalledWith("bob", persona.PANDA_TEMPLATE);
+      expect(getPendingInquiryTemplate).toHaveBeenCalledWith("bob", "basic");
+      await expect(response.json()).resolves.toStrictEqual({ code: "not started", legacy: "kyc not started" });
+      expect(response.status).toBe(400);
+    });
+
+    it("returns not legacy when old plugin with non-approved cryptomate inquiry", async () => {
+      await database
+        .update(credentials)
+        .set({ pandaId: null, factory: legacyFactory })
+        .where(eq(credentials.id, "bob"));
+      vi.spyOn(publicClient, "readContract").mockResolvedValueOnce([legacyPlugin]);
+      const getInquiry = vi.spyOn(persona, "getInquiry");
+      getInquiry.mockImplementation((_credentialId, templateId) => {
+        if (templateId === persona.CRYPTOMATE_TEMPLATE) {
+          return Promise.resolve({
+            ...personaTemplate,
+            attributes: { ...personaTemplate.attributes, status: "pending" },
+          });
+        }
+        return Promise.resolve(undefined); // eslint-disable-line unicorn/no-useless-undefined
+      });
+      const getPendingInquiryTemplate = vi.spyOn(persona, "getPendingInquiryTemplate").mockResolvedValueOnce(undefined); // eslint-disable-line unicorn/no-useless-undefined
+
+      const response = await appClient.index.$get(
+        { query: { scope: "basic" } },
+        { headers: { "test-credential-id": "bob" } },
+      );
+
+      expect(getPendingInquiryTemplate).toHaveBeenCalledWith("bob", "basic");
+      await expect(response.json()).resolves.toStrictEqual({ code: "ok", legacy: "ok" });
+      expect(response.status).toBe(200);
+    });
+
+    it("returns not legacy when old plugin with no cryptomate inquiry", async () => {
+      await database
+        .update(credentials)
+        .set({ pandaId: null, factory: legacyFactory })
+        .where(eq(credentials.id, "bob"));
+      vi.spyOn(publicClient, "readContract").mockResolvedValueOnce([legacyPlugin]);
+      const getInquiry = vi.spyOn(persona, "getInquiry");
+      getInquiry.mockResolvedValue(undefined); // eslint-disable-line unicorn/no-useless-undefined
+      const getPendingInquiryTemplate = vi.spyOn(persona, "getPendingInquiryTemplate").mockResolvedValueOnce(undefined); // eslint-disable-line unicorn/no-useless-undefined
+
+      const response = await appClient.index.$get(
+        { query: { scope: "basic" } },
+        { headers: { "test-credential-id": "bob" } },
+      );
+
+      expect(getPendingInquiryTemplate).toHaveBeenCalledWith("bob", "basic");
+      await expect(response.json()).resolves.toStrictEqual({ code: "ok", legacy: "ok" });
+      expect(response.status).toBe(200);
+    });
   });
 
-  it("returns ok kyc approved without template", async () => {
-    await database.update(credentials).set({ pandaId: null }).where(eq(credentials.id, "bob"));
-    const getInquiry = vi.spyOn(persona, "getInquiry").mockResolvedValueOnce(personaTemplate);
-    const getAccount = vi.spyOn(persona, "getAccount").mockResolvedValueOnce({
-      ...personaTemplate,
-      type: "account",
-      attributes: {
-        "country-code": "AR",
-        "social-security-number": null,
-        "address-street-1": "123 Main St",
-        "address-street-2": null,
-        "address-city": "New York",
-        "address-subdivision": null,
-        "address-postal-code": "10001",
-        fields: {},
-      },
+  describe("legacy kyc flow", () => {
+    it("returns ok kyc approved with country code", async () => {
+      await database.update(credentials).set({ pandaId: "pandaId" }).where(eq(credentials.id, "bob"));
+      const getInquiry = vi.spyOn(persona, "getInquiry");
+      const getAccount = vi
+        .spyOn(persona, "getAccount")
+        .mockResolvedValueOnce(basicAccount as persona.AccountOutput<"basic">);
+
+      const response = await appClient.index.$get(
+        { query: { countryCode: "true" } },
+        { headers: { "test-credential-id": "bob", SessionID: "fakeSession" } },
+      );
+
+      expect(getAccount).toHaveBeenCalledOnce();
+      expect(getInquiry).not.toHaveBeenCalled();
+      await expect(response.json()).resolves.toStrictEqual({ code: "ok", legacy: "ok" });
+      expect(response.headers.get("User-Country")).toBe("AR");
+      expect(response.status).toBe(200);
     });
 
-    const response = await appClient.index.$get(
-      { query: {} },
-      { headers: { "test-credential-id": "bob", SessionID: "fakeSession" } },
-    );
+    it("returns ok kyc approved when panda id is present", async () => {
+      await database.update(credentials).set({ pandaId: "pandaId" }).where(eq(credentials.id, "bob"));
+      const getInquiry = vi.spyOn(persona, "getInquiry");
+      const getAccount = vi.spyOn(persona, "getAccount");
 
-    expect(getInquiry).toHaveBeenCalledWith("bob", "itmpl_8uim4FvD5P3kFpKHX37CW817");
-    expect(getAccount).toHaveBeenCalledOnce();
-    await expect(response.json()).resolves.toStrictEqual({ code: "ok", legacy: "ok" });
-    expect(response.headers.get("User-Country")).toBe("AR");
-    expect(response.status).toBe(200);
-  });
+      const response = await appClient.index.$get(
+        { query: {} },
+        { headers: { "test-credential-id": "bob", SessionID: "fakeSession" } },
+      );
 
-  it("resumes inquiry with template", async () => {
-    const templateId = persona.PANDA_TEMPLATE;
-    const getInquiry = vi.spyOn(persona, "getInquiry").mockResolvedValueOnce({
-      ...personaTemplate,
-      attributes: { ...personaTemplate.attributes, status: "pending" },
-    });
-    const resumeInquiry = vi.spyOn(persona, "resumeInquiry").mockResolvedValueOnce(resumeTemplate);
-
-    const response = await appClient.index.$get(
-      { query: { templateId } },
-      { headers: { "test-credential-id": "bob", SessionID: "fakeSession" } },
-    );
-
-    expect(getInquiry).toHaveBeenCalledWith("bob", templateId);
-    expect(resumeInquiry).toHaveBeenCalledWith(resumeTemplate.data.id);
-    await expect(response.json()).resolves.toStrictEqual({
-      inquiryId: resumeTemplate.data.id,
-      sessionToken: resumeTemplate.meta["session-token"],
-    });
-    expect(response.status).toBe(200);
-  });
-
-  it("returns OTL link", async () => {
-    const otl = "https://new-url.com";
-    const generateOTL = vi.spyOn(persona, "generateOTL").mockResolvedValueOnce({
-      ...OTLTemplate,
-      meta: { ...OTLTemplate.meta, "one-time-link": otl },
-    });
-    let templateId;
-    const getInquiry = vi.spyOn(persona, "getInquiry").mockResolvedValueOnce(templateId);
-    const createInquiry = vi.spyOn(persona, "createInquiry").mockResolvedValueOnce(OTLTemplate);
-
-    const response = await appClient.index.$post(
-      { json: {} },
-      { headers: { "test-credential-id": "bob", SessionID: "fakeSession" } },
-    );
-
-    expect(getInquiry).toHaveBeenCalledWith("bob", persona.CRYPTOMATE_TEMPLATE);
-    expect(createInquiry).toHaveBeenCalledWith("bob", undefined);
-    expect(generateOTL).toHaveBeenCalledWith(resumeTemplate.data.id);
-    await expect(response.json()).resolves.toStrictEqual({ otl, legacy: otl });
-    expect(response.status).toBe(200);
-  });
-
-  it("returns OTL link when resuming inquiry", async () => {
-    const templateId = "template";
-    const otl = "https://resume-url.com";
-    const generateOTL = vi.spyOn(persona, "generateOTL").mockResolvedValueOnce({
-      ...OTLTemplate,
-      meta: { ...OTLTemplate.meta, "one-time-link": otl },
+      expect(getAccount).not.toHaveBeenCalled();
+      expect(getInquiry).not.toHaveBeenCalled();
+      await expect(response.json()).resolves.toStrictEqual({ code: "ok", legacy: "ok" });
+      expect(response.status).toBe(200);
     });
 
-    const getInquiry = vi.spyOn(persona, "getInquiry").mockResolvedValueOnce({
-      ...personaTemplate,
-      attributes: { ...personaTemplate.attributes, status: "created" },
-    });
-    const response = await appClient.index.$post(
-      { json: { templateId } },
-      { headers: { "test-credential-id": "bob", SessionID: "fakeSession" } },
-    );
+    it("resumes inquiry with template", async () => {
+      await database.update(credentials).set({ pandaId: null }).where(eq(credentials.id, "bob"));
+      const templateId = persona.PANDA_TEMPLATE;
+      const getInquiry = vi.spyOn(persona, "getInquiry").mockResolvedValueOnce({
+        ...personaTemplate,
+        attributes: { ...personaTemplate.attributes, status: "pending" },
+      });
+      const resumeInquiry = vi.spyOn(persona, "resumeInquiry").mockResolvedValueOnce(resumeTemplate);
 
-    expect(getInquiry).toHaveBeenCalledWith("bob", templateId);
-    expect(generateOTL).toHaveBeenCalledWith(resumeTemplate.data.id);
-    await expect(response.json()).resolves.toStrictEqual({ otl, legacy: otl });
-    expect(response.status).toBe(200);
+      const response = await appClient.index.$get(
+        { query: { templateId } },
+        { headers: { "test-credential-id": "bob", SessionID: "fakeSession" } },
+      );
+
+      expect(getInquiry).toHaveBeenCalledWith("bob", templateId);
+      expect(resumeInquiry).toHaveBeenCalledWith(resumeTemplate.data.id);
+      await expect(response.json()).resolves.toStrictEqual({
+        inquiryId: resumeTemplate.data.id,
+        sessionToken: resumeTemplate.meta["session-token"],
+      });
+      expect(response.status).toBe(200);
+    });
+
+    it("returns OTL and session token when creating inquiry", async () => {
+      await database.update(credentials).set({ pandaId: null }).where(eq(credentials.id, "bob"));
+
+      const otl = "https://new-url.com";
+      const sessionToken = "persona-session-token";
+
+      vi.spyOn(persona, "generateOTL").mockResolvedValueOnce({
+        ...OTLTemplate,
+        meta: { ...OTLTemplate.meta, "one-time-link": otl },
+      });
+      vi.spyOn(persona, "resumeInquiry").mockResolvedValueOnce({
+        ...resumeTemplate,
+        meta: { ...resumeTemplate.meta, "session-token": sessionToken },
+      });
+      vi.spyOn(persona, "getInquiry").mockResolvedValueOnce(undefined); // eslint-disable-line unicorn/no-useless-undefined
+
+      const getPendingInquiryTemplate = vi
+        .spyOn(persona, "getPendingInquiryTemplate")
+        .mockResolvedValueOnce(persona.PANDA_TEMPLATE);
+      const createInquiry = vi.spyOn(persona, "createInquiry").mockResolvedValueOnce(OTLTemplate);
+
+      const response = await appClient.index.$post(
+        { json: {} },
+        { headers: { "test-credential-id": "bob", SessionID: "fakeSession" } },
+      );
+
+      expect(getPendingInquiryTemplate).toHaveBeenCalledWith("bob", "basic");
+      expect(createInquiry).toHaveBeenCalledWith("bob", persona.PANDA_TEMPLATE, undefined);
+      await expect(response.json()).resolves.toStrictEqual({
+        otl,
+        sessionToken,
+        legacy: otl,
+        inquiryId: resumeTemplate.data.id,
+      });
+      expect(response.status).toBe(200);
+    });
+
+    it("returns OTL link and session token when resuming inquiry", async () => {
+      const templateId = "template";
+      const otl = "https://resume-url.com";
+      const sessionToken = "persona-session-token";
+
+      vi.spyOn(persona, "generateOTL").mockResolvedValueOnce({
+        ...OTLTemplate,
+        meta: { ...OTLTemplate.meta, "one-time-link": otl },
+      });
+      vi.spyOn(persona, "resumeInquiry").mockResolvedValueOnce({
+        ...resumeTemplate,
+        meta: { ...resumeTemplate.meta, "session-token": sessionToken },
+      });
+      const getPendingInquiryTemplate = vi
+        .spyOn(persona, "getPendingInquiryTemplate")
+        .mockResolvedValueOnce(persona.PANDA_TEMPLATE);
+      const getInquiry = vi.spyOn(persona, "getInquiry").mockResolvedValueOnce({
+        ...personaTemplate,
+        attributes: { ...personaTemplate.attributes, status: "created" },
+      });
+      const response = await appClient.index.$post(
+        { json: { templateId } },
+        { headers: { "test-credential-id": "bob" } },
+      );
+
+      expect(getPendingInquiryTemplate).toHaveBeenCalledWith("bob", "basic");
+      expect(getInquiry).toHaveBeenCalledWith("bob", persona.PANDA_TEMPLATE);
+      await expect(response.json()).resolves.toStrictEqual({
+        otl,
+        sessionToken,
+        legacy: otl,
+        inquiryId: resumeTemplate.data.id,
+      });
+      expect(response.status).toBe(200);
+    });
   });
 });
+
+const basicAccount = {
+  type: "account",
+  id: "test-account-id",
+  attributes: {
+    "reference-id": "test-reference-id",
+    "created-at": "2025-12-01T00:00:00.000Z",
+    "updated-at": "2025-12-01T00:00:00.000Z",
+    "redacted-at": null,
+    "account-type-name": "User",
+    fields: {
+      name: {
+        type: "hash",
+        value: {
+          first: {
+            type: "string",
+            value: "ALEXANDER J",
+          },
+          middle: {
+            type: "string",
+            value: null,
+          },
+          last: {
+            type: "string",
+            value: "SAMPLE",
+          },
+        },
+      },
+      address: {
+        type: "hash",
+        value: {
+          street_1: {
+            type: "string",
+            value: "600 CALIFORNIA STREET",
+          },
+          street_2: {
+            type: "string",
+            value: null,
+          },
+          city: {
+            type: "string",
+            value: "SAN FRANCISCO",
+          },
+          subdivision: {
+            type: "string",
+            value: "CA",
+          },
+          postal_code: {
+            type: "string",
+            value: "94109",
+          },
+          country_code: {
+            type: "string",
+            value: "US",
+          },
+        },
+      },
+      identification_numbers: {
+        type: "array",
+        value: [
+          {
+            type: "hash",
+            value: {
+              identification_class: {
+                type: "string",
+                value: "dl",
+              },
+              identification_number: {
+                type: "string",
+                value: "I1234562",
+              },
+              issuing_country: {
+                type: "string",
+                value: "US",
+              },
+            },
+          },
+        ],
+      },
+      birthdate: {
+        type: "date",
+        value: "1977-07-17",
+      },
+      phone_number: {
+        type: "string",
+        value: "+1234567890",
+      },
+      email_address: {
+        type: "string",
+        value: "example@example.com",
+      },
+      selfie_photo: {
+        type: "file",
+        value: {
+          filename: "selfie.jpg",
+          byte_size: 20_723,
+          url: "https://url.to.selfie.photo",
+        },
+      },
+      tin: {
+        type: "string",
+        value: null,
+      },
+      isnotfacta: {
+        // cspell:ignore isnotfacta
+        type: "boolean",
+        value: null,
+      },
+      manteca_t_c: {
+        type: "boolean",
+        value: null,
+      },
+      rain_e_sign_consent: {
+        type: "boolean",
+        value: true,
+      },
+      exa_card_tc: {
+        type: "boolean",
+        value: true,
+      },
+      privacy__policy: {
+        type: "boolean",
+        value: true,
+      },
+      sex_1: {
+        type: "string",
+        value: null,
+      },
+      account_opening_disclosure: {
+        type: "boolean",
+        value: true,
+      },
+      economic_activity: {
+        type: "string",
+        value: "Engineer",
+      },
+      annual_salary: {
+        type: "string",
+        value: "100000",
+      },
+      expected_monthly_volume: {
+        type: "string",
+        value: "1000",
+      },
+      accurate_info_confirmation: {
+        type: "boolean",
+        value: true,
+      },
+      non_unauthorized_solicitation: {
+        type: "boolean",
+        value: true,
+      },
+      non_illegal_activities_2: {
+        type: "string",
+        value: "No",
+      },
+      documents: {
+        type: "array",
+        value: [
+          {
+            type: "hash",
+            value: {
+              id_class: {
+                type: "string",
+                value: "dl",
+              },
+              id_number: {
+                type: "string",
+                value: "1234567890",
+              },
+              id_issuing_country: {
+                type: "string",
+                value: "US",
+              },
+              id_document_id: {
+                type: "string",
+                value: "doc_1234567890",
+              },
+            },
+          },
+        ],
+      },
+    },
+    "name-first": "ALEXANDER J",
+    "name-middle": null,
+    "name-last": "SAMPLE",
+    "social-security-number": null,
+    "address-street-1": "600 CALIFORNIA STREET",
+    "address-street-2": null,
+    "address-city": "SAN FRANCISCO",
+    "address-subdivision": "CA",
+    "address-postal-code": "94109",
+    "country-code": "AR",
+    birthdate: "1977-07-17",
+    "phone-number": "+1234567890",
+    "email-address": "example@example.com",
+    tags: [],
+    "account-status": "Default",
+    "identification-numbers": {
+      dl: [
+        {
+          "issuing-country": "US",
+          "identification-class": "dl",
+          "identification-number": "I1234562",
+          "created-at": "2025-12-11T00:00:00.000Z",
+          "updated-at": "2025-12-11T00:00:00.000Z",
+        },
+      ],
+    },
+  },
+};
 
 const personaTemplate = {
   id: "test-id",
@@ -213,5 +1105,16 @@ const OTLTemplate = {
   meta: {
     "one-time-link": "a link",
     "one-time-link-short": "",
+  },
+} as const;
+
+const inquiry = {
+  data: {
+    id: "test-id",
+    type: "inquiry",
+    attributes: {
+      status: "created",
+      "reference-id": "ref-123",
+    },
   },
 } as const;

--- a/server/test/utils/persona.test.ts
+++ b/server/test/utils/persona.test.ts
@@ -1,0 +1,698 @@
+import "../mocks/persona";
+import "../mocks/sentry";
+
+import { array, minLength, number, object, optional, pipe, safeParse, string, union } from "valibot";
+import { describe, expect, it, vi } from "vitest";
+
+import * as persona from "../../utils/persona";
+
+vi.mock("../../utils/panda");
+vi.mock("../../utils/pax");
+vi.mock("@sentry/node", { spy: true });
+
+describe("is missing or null util", () => {
+  const schema = object({
+    field1: string(),
+    field2: optional(string()),
+    array: pipe(
+      array(
+        object({
+          arrayField1: string(),
+          arrayField2: optional(string()),
+        }),
+      ),
+      minLength(1),
+    ),
+    union: union(
+      [
+        object({ field1: string(), field1optional: optional(string()) }),
+        object({ field2: number(), field2optional: optional(number()) }),
+      ],
+      "error message",
+    ),
+    nested: object({
+      nestedField1: string(),
+      nestedField2: optional(string()),
+      nestedArray: array(string()),
+    }),
+  });
+
+  it("returns true if field is null or undefined", () => {
+    const result = safeParse(schema, {
+      field1: null,
+      array: [{ arrayField1: "test" }],
+      union: { field1: "test" },
+      nested: {
+        nestedField1: "test",
+        nestedArray: [],
+      },
+    });
+    const issue = result.issues?.[0];
+
+    expect(result.success).toBe(false);
+    expect(result.issues).toHaveLength(1);
+    expect(issue && persona.isMissingOrNull(issue)).toBe(true);
+  });
+
+  it("returns false if field is not valid", () => {
+    const result = safeParse(schema, {
+      field1: 123,
+      array: [{ arrayField1: "test" }],
+      union: { field1: "test" },
+      nested: {
+        nestedField1: "test",
+        nestedArray: [],
+      },
+    });
+    const issue = result.issues?.[0];
+
+    expect(result.success).toBe(false);
+    expect(result.issues).toHaveLength(1);
+    expect(issue && persona.isMissingOrNull(issue)).toBe(false);
+  });
+
+  it("returns true if nested field is null or undefined", () => {
+    const result = safeParse(schema, {
+      field1: "test",
+      array: [{ arrayField1: "test" }],
+      union: { field1: "test" },
+      nested: {
+        nestedField1: null,
+        nestedArray: [],
+      },
+    });
+    const issue = result.issues?.[0];
+
+    expect(result.success).toBe(false);
+    expect(result.issues?.length).toBe(1);
+    expect(issue && persona.isMissingOrNull(issue)).toBe(true);
+  });
+
+  it("returns true if union is null or undefined", () => {
+    const result = safeParse(schema, {
+      field1: "test",
+      array: [{ arrayField1: "test" }],
+      union: null,
+      nested: {
+        nestedField1: "test",
+        nestedArray: [],
+      },
+    });
+    const issue = result.issues?.[0];
+
+    expect(result.success).toBe(false);
+    expect(result.issues).toHaveLength(1);
+    expect(issue?.issues).toHaveLength(2);
+    expect(issue && persona.isMissingOrNull(issue)).toBe(true);
+  });
+
+  it("returns true if union is defined but all sub issues are undefined or null", () => {
+    const result = safeParse(schema, {
+      field1: "test",
+      array: [{ arrayField1: "test" }],
+      union: { field2: null },
+      nested: {
+        nestedField1: "test",
+        nestedArray: [],
+      },
+    });
+    const issue = result.issues?.[0];
+
+    expect(result.success).toBe(false);
+    expect(result.issues).toHaveLength(1);
+    expect(issue?.issues).toHaveLength(2);
+    expect(issue && persona.isMissingOrNull(issue)).toBe(true);
+  });
+
+  it("returns false if union is defined and at least one sub issue is not undefined or null", () => {
+    const result = safeParse(schema, {
+      field1: "test",
+      array: [{ arrayField1: "test" }],
+      union: { field2: "test", field2optional: 123 },
+      nested: {
+        nestedField1: "test",
+        nestedArray: [],
+      },
+    });
+    const issue = result.issues?.[0];
+
+    expect(result.success).toBe(false);
+    expect(result.issues).toHaveLength(1);
+    expect(issue?.issues).toHaveLength(2);
+    expect(issue && persona.isMissingOrNull(issue)).toBe(false);
+  });
+
+  it("returns true if array is empty and min length is 1", () => {
+    const result = safeParse(schema, {
+      field1: "test",
+      array: [],
+      union: { field1: "test" },
+      nested: {
+        nestedField1: "test",
+        nestedArray: [],
+      },
+    });
+    const issue = result.issues?.[0];
+
+    expect(result.success).toBe(false);
+    expect(result.issues).toHaveLength(1);
+    expect(issue && persona.isMissingOrNull(issue)).toBe(true);
+  });
+});
+
+describe("evaluateAccount", () => {
+  it("throws when scope is not supported", () => {
+    expect(() => persona.evaluateAccount({ data: [] }, "invalid" as persona.AccountScope)).toThrow(
+      "unhandled account scope: invalid",
+    );
+  });
+
+  describe("basic", () => {
+    it("returns panda template when account not found", () => {
+      const result = persona.evaluateAccount({ data: [] }, "basic");
+
+      expect(result).toBe(persona.PANDA_TEMPLATE);
+    });
+
+    it("returns panda template when all fields are missing", () => {
+      const result = persona.evaluateAccount(emptyAccount, "basic");
+
+      expect(result).toBe(persona.PANDA_TEMPLATE);
+    });
+
+    it("returns undefined when account exists and is valid", () => {
+      const result = persona.evaluateAccount(basicAccount, "basic");
+
+      expect(result).toBeUndefined();
+    });
+
+    it("throws when account exists but is invalid", () => {
+      expect(() =>
+        persona.evaluateAccount(
+          { data: [{ id: "acc-123", type: "account", attributes: { "country-code": 3 } }] },
+          "basic",
+        ),
+      ).toThrow(persona.scopeValidationErrors.INVALID_SCOPE_VALIDATION);
+    });
+  });
+
+  describe("manteca", () => {
+    it("returns panda template when account not found", () => {
+      const result = persona.evaluateAccount({ data: [] }, "manteca");
+
+      expect(result).toBe(persona.PANDA_TEMPLATE);
+    });
+
+    it("returns manteca template when account exists and id class is allowed", () => {
+      const result = persona.evaluateAccount(basicAccount, "manteca");
+
+      expect(result).toBe(persona.MANTECA_TEMPLATE_EXTRA_FIELDS);
+    });
+
+    it("throws when account exists but country is not allowed", () => {
+      expect(() =>
+        persona.evaluateAccount(
+          {
+            data: [
+              {
+                ...mantecaAccount.data[0],
+                type: "account" as const,
+                id: "test-account-id",
+                attributes: {
+                  ...mantecaAccount.data[0]?.attributes,
+                  "country-code": "XX",
+                },
+              },
+            ],
+          },
+          "manteca",
+        ),
+      ).toThrow(persona.scopeValidationErrors.NOT_SUPPORTED);
+    });
+
+    it("returns panda template when account exists but basic scope is not valid", () => {
+      const result = persona.evaluateAccount(emptyAccount, "manteca");
+
+      expect(result).toBe(persona.PANDA_TEMPLATE);
+    });
+
+    it("returns manteca template when new account has a id class that is not allowed", () => {
+      const result = persona.evaluateAccount(
+        {
+          data: [
+            {
+              ...basicAccount.data[0],
+              type: "account" as const,
+              id: "test-account-id",
+              attributes: {
+                ...basicAccount.data[0]?.attributes,
+                fields: {
+                  ...basicAccount.data[0]?.attributes.fields,
+                  documents: {
+                    value: [
+                      {
+                        value: {
+                          ...basicAccount.data[0]?.attributes.fields.documents.value[0]?.value,
+                          id_class: { value: "invalid" },
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          ],
+        },
+        "manteca",
+      );
+
+      expect(result).toBe(persona.MANTECA_TEMPLATE_WITH_ID_CLASS);
+    });
+
+    it("returns undefined when account exists and id class is allowed", () => {
+      const result = persona.evaluateAccount(mantecaAccount, "manteca");
+
+      expect(result).toBeUndefined();
+    });
+
+    it("throws when schema validation fails", () => {
+      expect(() =>
+        persona.evaluateAccount(
+          {
+            data: [
+              {
+                ...mantecaAccount.data[0],
+                type: "account" as const,
+                id: "test-account-id",
+                attributes: {
+                  ...mantecaAccount.data[0]?.attributes,
+                  fields: {
+                    ...mantecaAccount.data[0]?.attributes.fields,
+                    tin: { type: "string", value: 123 },
+                  },
+                },
+              },
+            ],
+          },
+          "manteca",
+        ),
+      ).toThrow(persona.scopeValidationErrors.INVALID_SCOPE_VALIDATION);
+    });
+  });
+});
+
+const emptyAccount = {
+  data: [
+    {
+      type: "account" as const,
+      id: "test-account-id",
+      attributes: {
+        "reference-id": "test-reference-id",
+        "created-at": "2025-12-01T00:00:00.000Z",
+        "updated-at": "2025-12-01T00:00:00.000Z",
+        "redacted-at": null,
+        "account-type-name": "User",
+        fields: {
+          name: {
+            type: "hash",
+            value: {
+              first: {
+                type: "string",
+                value: null,
+              },
+              middle: {
+                type: "string",
+                value: null,
+              },
+              last: {
+                type: "string",
+                value: null,
+              },
+            },
+          },
+          address: {
+            type: "hash",
+            value: {
+              street_1: {
+                type: "string",
+                value: null,
+              },
+              street_2: {
+                type: "string",
+                value: null,
+              },
+              city: {
+                type: "string",
+                value: null,
+              },
+              subdivision: {
+                type: "string",
+                value: null,
+              },
+              postal_code: {
+                type: "string",
+                value: null,
+              },
+              country_code: {
+                type: "string",
+                value: null,
+              },
+            },
+          },
+          identification_numbers: {
+            type: "array",
+            value: [],
+          },
+          birthdate: {
+            type: "date",
+            value: null,
+          },
+          phone_number: {
+            type: "string",
+            value: null,
+          },
+          email_address: {
+            type: "string",
+            value: null,
+          },
+          selfie_photo: {
+            type: "file",
+            value: null,
+          },
+          tin: {
+            type: "string",
+            value: null,
+          },
+          isnotfacta: {
+            // cspell:ignore isnotfacta
+            type: "boolean",
+            value: null,
+          },
+          sex: {
+            type: "choices",
+            value: null,
+          },
+          manteca_t_c: {
+            type: "boolean",
+            value: null,
+          },
+          rain_e_sign_consent: {
+            type: "boolean",
+            value: null,
+          },
+          exa_card_tc: {
+            type: "boolean",
+            value: null,
+          },
+          privacy__policy: {
+            type: "boolean",
+            value: null,
+          },
+          sex_1: {
+            type: "string",
+            value: null,
+          },
+          account_opening_disclosure: {
+            type: "boolean",
+            value: null,
+          },
+          documents: {
+            type: "array",
+            value: [],
+          },
+        },
+        "name-first": null,
+        "name-middle": null,
+        "name-last": null,
+        "social-security-number": null,
+        "address-street-1": null,
+        "address-street-2": null,
+        "address-city": null,
+        "address-subdivision": null,
+        "address-postal-code": null,
+        "country-code": null,
+        birthdate: null,
+        "phone-number": null,
+        "email-address": null,
+        tags: [],
+        "account-status": "Default",
+        "identification-numbers": {},
+      },
+      relationships: {
+        "account-type": {
+          data: {
+            type: "account-type",
+            id: "account-type-id",
+          },
+        },
+      },
+    },
+  ],
+};
+
+const basicAccount = {
+  data: [
+    {
+      type: "account" as const,
+      id: "test-account-id",
+      attributes: {
+        "reference-id": "test-reference-id",
+        "created-at": "2025-12-01T00:00:00.000Z",
+        "updated-at": "2025-12-01T00:00:00.000Z",
+        "redacted-at": null,
+        "account-type-name": "User",
+        fields: {
+          name: {
+            type: "hash",
+            value: {
+              first: {
+                type: "string",
+                value: "ALEXANDER J",
+              },
+              middle: {
+                type: "string",
+                value: null,
+              },
+              last: {
+                type: "string",
+                value: "SAMPLE",
+              },
+            },
+          },
+          address: {
+            type: "hash",
+            value: {
+              street_1: {
+                type: "string",
+                value: "600 CALIFORNIA STREET",
+              },
+              street_2: {
+                type: "string",
+                value: null,
+              },
+              city: {
+                type: "string",
+                value: "SAN FRANCISCO",
+              },
+              subdivision: {
+                type: "string",
+                value: "CA",
+              },
+              postal_code: {
+                type: "string",
+                value: "94109",
+              },
+              country_code: {
+                type: "string",
+                value: "US",
+              },
+            },
+          },
+          identification_numbers: {
+            type: "array",
+            value: [
+              {
+                type: "hash",
+                value: {
+                  identification_class: {
+                    type: "string",
+                    value: "dl",
+                  },
+                  identification_number: {
+                    type: "string",
+                    value: "I1234562",
+                  },
+                  issuing_country: {
+                    type: "string",
+                    value: "US",
+                  },
+                },
+              },
+            ],
+          },
+          birthdate: {
+            type: "date",
+            value: "1977-07-17",
+          },
+          phone_number: {
+            type: "string",
+            value: "+1234567890",
+          },
+          email_address: {
+            type: "string",
+            value: "example@example.com",
+          },
+          selfie_photo: {
+            type: "file",
+            value: {
+              filename: "selfie.jpg",
+              byte_size: 20_723,
+              url: "https://url.to.selfie.photo",
+            },
+          },
+          tin: {
+            type: "string",
+            value: null,
+          },
+          isnotfacta: {
+            // cspell:ignore isnotfacta
+            type: "boolean",
+            value: null,
+          },
+          manteca_t_c: {
+            type: "boolean",
+            value: null,
+          },
+          rain_e_sign_consent: {
+            type: "boolean",
+            value: true,
+          },
+          exa_card_tc: {
+            type: "boolean",
+            value: true,
+          },
+          privacy__policy: {
+            type: "boolean",
+            value: true,
+          },
+          sex_1: {
+            type: "string",
+            value: null,
+          },
+          account_opening_disclosure: {
+            type: "boolean",
+            value: true,
+          },
+          economic_activity: {
+            type: "string",
+            value: "Engineer",
+          },
+          annual_salary: {
+            type: "string",
+            value: "100000",
+          },
+          expected_monthly_volume: {
+            type: "string",
+            value: "1000",
+          },
+          accurate_info_confirmation: {
+            type: "boolean",
+            value: true,
+          },
+          non_unauthorized_solicitation: {
+            type: "boolean",
+            value: true,
+          },
+          non_illegal_activities_2: {
+            type: "string",
+            value: "No",
+          },
+          documents: {
+            type: "array",
+            value: [
+              {
+                type: "hash",
+                value: {
+                  id_class: {
+                    type: "string",
+                    value: "dl",
+                  },
+                  id_number: {
+                    type: "string",
+                    value: "1234567890",
+                  },
+                  id_issuing_country: {
+                    type: "string",
+                    value: "US",
+                  },
+                  id_document_id: {
+                    type: "string",
+                    value: "doc_1234567890",
+                  },
+                },
+              },
+            ],
+          },
+        },
+        "name-first": "ALEXANDER J",
+        "name-middle": null,
+        "name-last": "SAMPLE",
+        "social-security-number": null,
+        "address-street-1": "600 CALIFORNIA STREET",
+        "address-street-2": null,
+        "address-city": "SAN FRANCISCO",
+        "address-subdivision": "CA",
+        "address-postal-code": "94109",
+        "country-code": "US",
+        birthdate: "1977-07-17",
+        "phone-number": "+1234567890",
+        "email-address": "example@example.com",
+        tags: [],
+        "account-status": "Default",
+        "identification-numbers": {
+          dl: [
+            {
+              "issuing-country": "US",
+              "identification-class": "dl",
+              "identification-number": "I1234562",
+              "created-at": "2025-12-11T00:00:00.000Z",
+              "updated-at": "2025-12-11T00:00:00.000Z",
+            },
+          ],
+        },
+      },
+    },
+  ],
+};
+
+const mantecaAccount = {
+  data: [
+    {
+      ...basicAccount.data[0],
+      type: "account" as const,
+      id: "test-account-id",
+      attributes: {
+        ...basicAccount.data[0]?.attributes,
+        fields: {
+          ...basicAccount.data[0]?.attributes.fields,
+          tin: {
+            type: "string",
+            value: "12345678",
+          },
+          manteca_t_c: {
+            type: "boolean",
+            value: true,
+          },
+          sex_1: {
+            type: "string",
+            value: "Male",
+          },
+          isnotfacta: {
+            type: "boolean",
+            value: true,
+          },
+        },
+      },
+    },
+  ],
+};

--- a/server/utils/persona.ts
+++ b/server/utils/persona.ts
@@ -1,5 +1,5 @@
 import { vValidator } from "@hono/valibot-validator";
-import { setContext } from "@sentry/core";
+import { captureEvent, setContext } from "@sentry/core";
 import { createHmac, timingSafeEqual } from "node:crypto";
 import {
   array,
@@ -7,19 +7,21 @@ import {
   flatten,
   literal,
   nullable,
-  nullish,
-  number,
   object,
   picklist,
   safeParse,
   string,
+  unknown,
   ValiError,
-  variant,
   type BaseIssue,
   type BaseSchema,
+  type InferOutput,
 } from "valibot";
 
+import chain from "@exactly/common/generated/chain";
+
 import appOrigin from "./appOrigin";
+import { DevelopmentChainIds } from "./ramps/shared";
 
 if (!process.env.PERSONA_API_KEY) throw new Error("missing persona api key");
 if (!process.env.PERSONA_URL) throw new Error("missing persona url");
@@ -27,19 +29,14 @@ if (!process.env.PERSONA_WEBHOOK_SECRET) throw new Error("missing persona webhoo
 
 export const CRYPTOMATE_TEMPLATE = "itmpl_8uim4FvD5P3kFpKHX37CW817";
 export const PANDA_TEMPLATE = "itmpl_1igCJVqgf3xuzqKYD87HrSaDavU2";
-export const MANTECA_TEMPLATE = "itmpl_gjYZshv7bc1DK8DNL8YYTQ1muejo";
+export const MANTECA_TEMPLATE_EXTRA_FIELDS = "itmpl_gjYZshv7bc1DK8DNL8YYTQ1muejo";
+export const MANTECA_TEMPLATE_WITH_ID_CLASS = "itmpl_TjaqJdQYkht17v645zNFUfkaWNan";
+
+const PERSONA_API_VERSION = "2023-01-05";
 
 const authorization = `Bearer ${process.env.PERSONA_API_KEY}`;
 const baseURL = process.env.PERSONA_URL;
 const webhookSecret = process.env.PERSONA_WEBHOOK_SECRET;
-
-export async function getAccount(referenceId: string) {
-  const { data: accounts } = await request(
-    GetAccountsResponse,
-    `/accounts?page[size]=1&filter[reference-id]=${referenceId}`,
-  );
-  return accounts[0];
-}
 
 export async function getInquiry(referenceId: string, templateId: string) {
   const { data: approvedInquiries } = await request(
@@ -58,9 +55,9 @@ export function resumeInquiry(inquiryId: string) {
   return request(ResumeInquiryResponse, `/inquiries/${inquiryId}/resume`, undefined, "POST");
 }
 
-export function createInquiry(referenceId: string, redirectURI?: string) {
+export function createInquiry(referenceId: string, templateId: string, redirectURI?: string) {
   return request(CreateInquiryResponse, "/inquiries", {
-    data: { attributes: { "inquiry-template-id": PANDA_TEMPLATE, "redirect-uri": `${redirectURI ?? appOrigin}/card` } },
+    data: { attributes: { "inquiry-template-id": templateId, "redirect-uri": `${redirectURI ?? appOrigin}/card` } },
     meta: { "auto-create-account": true, "auto-create-account-reference-id": referenceId },
   });
 }
@@ -74,10 +71,49 @@ export async function getDocument(documentId: string) {
   return data;
 }
 
+export async function addDocument(referenceId: string, identityDocument: InferOutput<typeof IdentityDocument>) {
+  const account = await getAccount(referenceId, "document");
+  if (!account) throw new Error("account not found");
+  const existingDocument = account.attributes.fields.documents.value.find(
+    (document) => document.value.id_document_id.value === identityDocument.id_document_id.value,
+  );
+  if (existingDocument) {
+    captureEvent({ message: "document-already-exists", contexts: { id: existingDocument.value.id_document_id } });
+    return;
+  }
+  return request(
+    object({ data: object({ id: string() }) }),
+    `/accounts/${account.id}`,
+    {
+      data: {
+        attributes: {
+          fields: {
+            documents: [
+              ...account.attributes.fields.documents.value.map((document) => ({
+                id_class: document.value.id_class.value,
+                id_number: document.value.id_number.value,
+                id_issuing_country: document.value.id_issuing_country.value,
+                id_document_id: document.value.id_document_id.value,
+              })),
+              {
+                id_class: identityDocument.id_class.value,
+                id_number: identityDocument.id_number.value,
+                id_issuing_country: identityDocument.id_issuing_country.value,
+                id_document_id: identityDocument.id_document_id.value,
+              },
+            ],
+          },
+        },
+      },
+    },
+    "PATCH",
+  );
+}
+
 export async function resumeOrCreateMantecaInquiryOTL(referenceId: string, redirectURL?: string): Promise<string> {
   const { data: inquiries } = await request(
     GetMantecaInquiryResponse,
-    `/inquiries?page[size]=1&filter[reference-id]=${referenceId}&filter[inquiry-template-id]=${MANTECA_TEMPLATE}&filter[status]=created,pending`,
+    `/inquiries?page[size]=1&filter[reference-id]=${referenceId}&filter[inquiry-template-id]=${MANTECA_TEMPLATE_EXTRA_FIELDS}&filter[status]=created,pending`,
   );
 
   if (inquiries[0]) {
@@ -88,7 +124,10 @@ export async function resumeOrCreateMantecaInquiryOTL(referenceId: string, redir
   // TODO prefill inquiry with known fields
   const { data } = await request(CreateInquiryResponse, `/inquiries`, {
     data: {
-      attributes: { "inquiry-template-id": MANTECA_TEMPLATE, "redirect-uri": `${redirectURL ?? appOrigin}/` },
+      attributes: {
+        "inquiry-template-id": MANTECA_TEMPLATE_EXTRA_FIELDS,
+        "redirect-uri": `${redirectURL ?? appOrigin}/`,
+      },
     },
     meta: { "auto-create-account-reference-id": referenceId },
   });
@@ -105,7 +144,12 @@ async function request<TInput, TOutput, TIssue extends BaseIssue<unknown>>(
 ) {
   const response = await fetch(`${baseURL}${url}`, {
     method,
-    headers: { authorization, accept: "application/json", "content-type": "application/json" },
+    headers: {
+      authorization,
+      accept: "application/json",
+      "content-type": "application/json",
+      "persona-version": PERSONA_API_VERSION,
+    },
     body: body ? JSON.stringify(body) : undefined,
     signal: AbortSignal.timeout(timeout),
   });
@@ -120,109 +164,225 @@ async function request<TInput, TOutput, TIssue extends BaseIssue<unknown>>(
 
 export const IdentificationClasses = ["pp", "dl", "id", "wp", "rp"] as const;
 
-const Document = object({
-  filename: nullable(string()),
-  url: nullable(string()),
-  "byte-size": nullable(number()),
+const File = object({
+  filename: string(),
+  url: string(),
 });
 
-export const Documents = object({
+export const Document = object({
   id: string(),
   attributes: object({
-    "back-photo": nullable(Document),
-    "front-photo": nullable(Document),
-    "selfie-photo": nullable(Document),
+    "back-photo": nullable(File),
+    "front-photo": nullable(File),
+    "selfie-photo": nullable(File),
     "id-class": string(),
   }),
 });
 
-export const GetDocumentResponse = object({ data: Documents });
+export const GetDocumentResponse = object({ data: Document });
 
-type AccountCustomFields = {
-  address?: { value?: { country_code?: { value?: string } } };
-  isnotfacta?: boolean; // cspell:ignore isnotfacta
-  manteca_t_c?: boolean;
-  sex_1?: "Female" | "Male" | "Prefer not to say";
-  tin?: string;
-};
+const AccountMantecaFields = object({
+  isnotfacta: object({ value: boolean() }), // cspell:ignore isnotfacta
+  tin: object({ value: string() }),
+  sex_1: object({ value: picklist(["Male", "Female", "Prefer not to say"]) }),
+  manteca_t_c: object({ value: boolean() }),
+});
 
-const AccountFields = object({
-  // these are custom fields, if we change the name in the inquiry template we need to update it here
-  isnotfacta: nullish(object({ type: literal("boolean"), value: nullish(boolean()) })),
-  tin: nullish(object({ type: literal("string"), value: nullish(string()) })),
-  sex_1: nullish(object({ type: string(), value: nullish(picklist(["Male", "Female", "Prefer not to say"])) })),
-  manteca_t_c: nullish(object({ type: literal("boolean"), value: nullish(boolean()) })),
-  address: nullish(
-    object({
-      type: literal("hash"),
-      value: nullish(object({ country_code: nullish(object({ type: literal("string"), value: nullish(string()) })) })),
+export const IdentityDocument = object({
+  id_class: object({ value: string() }),
+  id_number: object({ value: string() }),
+  id_issuing_country: object({ value: string() }),
+  id_document_id: object({ value: string() }),
+});
+
+const AccountBasicFields = object({
+  name: object({
+    value: object({
+      first: object({ value: string() }),
+      middle: object({ value: nullable(string()) }),
+      last: object({ value: string() }),
     }),
-  ),
-} satisfies Record<keyof AccountCustomFields, unknown>);
-
-export const Account = object({
-  id: string(),
-  type: literal("account"),
-  attributes: object({
-    "country-code": nullable(string()),
-    "address-street-1": nullable(string()),
-    "address-street-2": nullable(string()),
-    "address-city": nullable(string()),
-    "address-subdivision": nullable(string()),
-    "address-postal-code": nullable(string()),
-    "social-security-number": nullable(string()),
-    fields: AccountFields,
+  }),
+  address: object({
+    value: object({
+      street_1: object({ value: string() }),
+      street_2: object({ value: nullable(string()) }),
+      city: object({ value: string() }),
+      subdivision: object({ value: string() }),
+      postal_code: object({ value: string() }),
+      country_code: object({ value: string() }),
+    }),
+  }),
+  birthdate: object({ value: string() }),
+  phone_number: object({ value: string() }),
+  email_address: object({ value: string() }),
+  selfie_photo: object({ value: File }),
+  rain_e_sign_consent: object({ value: boolean() }),
+  exa_card_tc: object({ value: boolean() }),
+  privacy__policy: object({ value: boolean() }),
+  account_opening_disclosure: object({ value: nullable(boolean()) }),
+  economic_activity: object({ value: string() }),
+  annual_salary: object({ value: string() }),
+  expected_monthly_volume: object({ value: string() }),
+  accurate_info_confirmation: object({ value: boolean() }),
+  non_unauthorized_solicitation: object({ value: boolean() }),
+  non_illegal_activities_2: object({ value: picklist(["Yes", "No"]) }),
+  documents: object({
+    value: array(
+      object({
+        value: object({
+          id_class: object({ value: string() }),
+          id_number: object({ value: string() }),
+          id_issuing_country: object({ value: string() }),
+          id_document_id: object({ value: string() }),
+        }),
+      }),
+    ),
   }),
 });
 
-const GetAccountsResponse = object({
-  data: array(Account),
+const BaseAccountAttributes = object({
+  fields: AccountBasicFields,
+  "country-code": string(),
+  "name-first": string(),
+  "name-middle": nullable(string()),
+  "name-last": string(),
+  "address-street-1": string(),
+  "address-street-2": nullable(string()),
+  "address-city": string(),
+  "address-subdivision": string(),
+  "address-postal-code": string(),
+  "social-security-number": nullable(string()),
+  "phone-number": string(),
+  "email-address": string(),
+  birthdate: string(),
 });
 
-const InquiryFields = object({
-  // these are custom fields, if we change the name in the inquiry template we need to update it here
-  "input-select": nullish(object({ type: literal("choices"), value: nullish(string()) })),
-  "address-street-1": nullish(object({ type: literal("string"), value: nullish(string()) })),
-  "address-street-2": nullish(object({ type: literal("string"), value: nullish(string()) })),
-  "address-city": nullish(object({ type: literal("string"), value: nullish(string()) })),
-  "address-subdivision": nullish(object({ type: literal("string"), value: nullish(string()) })),
-  "address-postal-code": nullish(object({ type: literal("string"), value: nullish(string()) })),
-  "social-security-number": nullish(object({ type: literal("string"), value: nullish(string()) })),
-  "identification-class": nullish(object({ type: literal("string"), value: nullish(string()) })),
-  "identification-number": nullish(object({ type: literal("string"), value: nullish(string()) })),
-  "current-government-id": nullish(object({ value: nullish(object({ id: nullish(string()) })) })),
+const BaseAccount = object({
+  id: string(),
+  type: literal("account"),
+  attributes: BaseAccountAttributes,
 });
+
+const DocumentAccount = object({
+  id: string(),
+  type: literal("account"),
+  attributes: object({
+    fields: object({
+      documents: object({ value: array(object({ value: IdentityDocument })) }),
+    }),
+  }),
+});
+
+const MantecaAccount = object({
+  ...BaseAccount.entries,
+  attributes: object({
+    ...BaseAccountAttributes.entries,
+    fields: object({ ...AccountBasicFields.entries, ...AccountMantecaFields.entries }),
+  }),
+});
+
+const UnknownAccount = object({
+  data: array(object({ id: string(), type: literal("account"), attributes: unknown() })),
+});
+
+const accountScopeSchemas = {
+  basic: object({ data: array(BaseAccount) }),
+  manteca: object({ data: array(MantecaAccount) }),
+  document: object({ data: array(DocumentAccount) }),
+} as const;
+
+export type AccountScope = keyof typeof accountScopeSchemas;
+type AccountResponse<T extends AccountScope> = InferOutput<(typeof accountScopeSchemas)[T]>;
+export type AccountOutput<T extends AccountScope> = AccountResponse<T>["data"][number];
+
+export function getAccounts<T extends AccountScope>(referenceId: string, scope: T): Promise<AccountResponse<T>> {
+  return request(accountScopeSchemas[scope], `/accounts?page[size]=1&filter[reference-id]=${referenceId}`);
+}
+
+export async function getAccount<T extends AccountScope>(
+  referenceId: string,
+  scope: T,
+): Promise<AccountOutput<T> | undefined> {
+  const { data } = await getAccounts(referenceId, scope);
+  return data[0];
+}
+
+function getUnknownAccount(referenceId: string) {
+  return request(UnknownAccount, `/accounts?page[size]=1&filter[reference-id]=${referenceId}`);
+}
+
+export async function getPendingInquiryTemplate(referenceId: string, scope: AccountScope): Promise<string | undefined> {
+  const unknownAccount = await getUnknownAccount(referenceId);
+  return evaluateAccount(unknownAccount, scope);
+}
+
+export function evaluateAccount(
+  unknownAccount: InferOutput<typeof UnknownAccount>,
+  scope: AccountScope,
+): typeof MANTECA_TEMPLATE_EXTRA_FIELDS | typeof MANTECA_TEMPLATE_WITH_ID_CLASS | typeof PANDA_TEMPLATE | undefined {
+  switch (scope) {
+    case "document":
+      throw new Error("document account scope not supported");
+    case "basic": {
+      const result = safeParse(accountScopeSchemas[scope], unknownAccount);
+      if (!result.success) {
+        const notMissingFieldsIssues = result.issues.filter((issue) => !isMissingOrNull(issue));
+        if (notMissingFieldsIssues.length === 0) return PANDA_TEMPLATE;
+
+        setContext("validation", { ...result, flatten: flatten(result.issues) });
+        throw new Error(scopeValidationErrors.INVALID_SCOPE_VALIDATION);
+      }
+      if (!result.output.data[0]) return PANDA_TEMPLATE;
+      return;
+    }
+    case "manteca": {
+      const requiredTemplate = evaluateAccount(unknownAccount, "basic");
+      // TODO use an unified template for panda + manteca
+      if (requiredTemplate) return requiredTemplate;
+
+      const basicAccount = safeParse(accountScopeSchemas.basic, unknownAccount);
+      if (!basicAccount.success) {
+        setContext("validation", { ...basicAccount, flatten: flatten(basicAccount.issues) });
+        throw new Error(scopeValidationErrors.INVALID_SCOPE_VALIDATION);
+      }
+
+      const countryCode = basicAccount.output.data[0]?.attributes["country-code"];
+      const userIdClasses = basicAccount.output.data[0]?.attributes.fields.documents.value.map(
+        (document) => document.value.id_class.value,
+      );
+      if (!userIdClasses?.length) throw new Error(scopeValidationErrors.INVALID_ACCOUNT);
+      if (!countryCode) throw new Error(scopeValidationErrors.INVALID_ACCOUNT);
+      const allowedIds = getAllowedMantecaIds(countryCode);
+      if (!allowedIds) throw new Error(scopeValidationErrors.NOT_SUPPORTED);
+
+      const result = safeParse(accountScopeSchemas[scope], unknownAccount);
+      if (!result.success) {
+        const notMissingFieldsIssues = result.issues.filter((issue) => !isMissingOrNull(issue));
+        if (notMissingFieldsIssues.length === 0) {
+          return allowedIds.some((id) => userIdClasses.includes(id))
+            ? MANTECA_TEMPLATE_EXTRA_FIELDS
+            : MANTECA_TEMPLATE_WITH_ID_CLASS;
+        }
+        setContext("validation", { ...result, flatten: flatten(result.issues) });
+        throw new Error(scopeValidationErrors.INVALID_SCOPE_VALIDATION);
+      }
+
+      return;
+    }
+    default: {
+      const exhaustive: never = scope;
+      throw new Error(`unhandled account scope: ${exhaustive as string}`);
+    }
+  }
+}
 
 export const Inquiry = object({
   id: string(),
   type: literal("inquiry"),
-  attributes: variant("status", [
-    object({
-      status: picklist(["completed", "approved"]),
-      "reference-id": string(),
-      "name-first": string(),
-      "name-middle": nullable(string()),
-      "name-last": string(),
-      "email-address": string(),
-      "phone-number": string(),
-      birthdate: string(),
-      fields: InquiryFields,
-    }),
-    object({
-      status: picklist(["created", "pending", "expired", "failed", "needs_review", "declined"]),
-      "reference-id": string(),
-      "name-first": nullable(string()),
-      "name-middle": nullable(string()),
-      "name-last": nullable(string()),
-      "email-address": nullable(string()),
-      "phone-number": nullable(string()),
-    }),
-  ]),
-  relationships: object({
-    documents: nullable(
-      object({ data: nullable(array(object({ id: nullable(string()), type: nullable(string()) }))) }),
-    ),
-    account: nullable(object({ data: nullable(object({ id: nullable(string()), type: nullable(string()) })) })),
+  attributes: object({
+    status: picklist(["created", "pending", "expired", "failed", "needs_review", "declined", "completed", "approved"]),
+    "reference-id": string(),
   }),
 });
 
@@ -233,26 +393,6 @@ const ResumeInquiryResponse = object({
   data: object({
     id: string(),
     type: literal("inquiry"),
-    attributes: object({
-      status: picklist([
-        "created",
-        "pending",
-        "expired",
-        "failed",
-        "needs_review",
-        "declined",
-        "completed",
-        "approved",
-      ]),
-      "reference-id": string(),
-      fields: object({
-        "name-first": object({ type: literal("string"), value: nullable(string()) }),
-        "name-middle": object({ type: literal("string"), value: nullable(string()) }),
-        "name-last": object({ type: literal("string"), value: nullable(string()) }),
-        "email-address": object({ type: literal("string"), value: nullable(string()) }),
-        "phone-number": object({ type: literal("string"), value: nullable(string()) }),
-      }),
-    }),
   }),
   meta: object({ "session-token": string() }),
 });
@@ -296,3 +436,47 @@ export function headerValidator() {
     return isVerified ? undefined : c.text("unauthorized", 401);
   });
 }
+
+export function isMissingOrNull<TInput>(issue: BaseIssue<TInput>): boolean {
+  if (issue.kind === "schema" && (issue.received === "null" || issue.input === undefined)) return true;
+  if (issue.kind === "validation" && issue.type === "min_length" && issue.received === "0") return true;
+  return issue.issues?.every((subIssue) => isMissingOrNull(subIssue)) ?? false;
+}
+
+export const MantecaCountryCode = [
+  "AR",
+  "CL",
+  "BR",
+  "CO",
+  "PA",
+  "CR",
+  "GT",
+  "MX",
+  "PH",
+  "BO",
+
+  // TODO for testing, remove
+  "US",
+] as const;
+
+type DevelopmentChain = (typeof DevelopmentChainIds)[number];
+type IdClass = (typeof IdentificationClasses)[number];
+type Country = (typeof MantecaCountryCode)[number];
+type Allowed = { allowedIds: readonly IdClass[] };
+const allowedMantecaCountries = new Map<Country, Allowed>([
+  ["AR", { allowedIds: ["id", "pp"] }],
+  ["BR", { allowedIds: ["id", "dl", "pp"] }],
+  ...(DevelopmentChainIds.includes(chain.id as DevelopmentChain)
+    ? ([["US", { allowedIds: ["dl"] }]] as const)
+    : ([] as const)),
+] satisfies (readonly [Country, Allowed])[]);
+
+export function getAllowedMantecaIds(country: string): readonly IdClass[] | undefined {
+  return allowedMantecaCountries.get(country as Country)?.allowedIds;
+}
+
+export const scopeValidationErrors = {
+  INVALID_SCOPE_VALIDATION: "invalid scope validation",
+  INVALID_ACCOUNT: "invalid account",
+  NOT_SUPPORTED: "not supported",
+} as const;

--- a/server/utils/ramps/shared.ts
+++ b/server/utils/ramps/shared.ts
@@ -6,6 +6,7 @@ export const Cryptocurrency = ["USDC", "USDT", "ETH", "SOL", "BTC", "DAI", "PYUS
 export const RampProvider = ["manteca", "bridge"] as const;
 
 export const SupportedChainId = [optimism.id, base.id, baseSepolia.id, optimismSepolia.id] as const;
+export const DevelopmentChainIds = [baseSepolia.id, optimismSepolia.id] as const;
 
 export const FiatNetwork = [
   "ARG_FIAT_TRANSFER",


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-template, scope-aware KYC flows with create/resume inquiries, session/OTL issuance, and identity document attachment.
  * Persona branching support for two onboarding templates (panda and manteca).

* **Improvements**
  * Better account/template resolution across scopes, legacy-KYC detection, and improved error/tracing.
  * Persona-versioned requests and added development-chain identifiers.

* **Tests**
  * Expanded end-to-end and unit tests covering scopes, templates, legacy flows, and edge cases.

* **Chores**
  * Several ramp/onboarding providers replaced with not-implemented placeholders.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exactly/exa/pull/637">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
