### PR TITLE
✨ server: add pax for platinum to signature card upgrades

### DIFF
--- a/.changeset/wise-comics-know.md
+++ b/.changeset/wise-comics-know.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+✨ add pax for platinum to signature card upgrades

--- a/server/test/mocks/pax.ts
+++ b/server/test/mocks/pax.ts
@@ -2,6 +2,6 @@ import { vi } from "vitest";
 
 vi.mock("../../utils/pax", async (importOriginal) => ({
   ...(await importOriginal()),
-  addCapita: vi.fn<() => Promise<Record<string, never>>>().mockResolvedValue({}),
-  removeCapita: vi.fn<() => Promise<void>>().mockResolvedValue(),
+  addCapita: vi.fn<(data: { internalId: string }) => Promise<Record<string, never>>>().mockResolvedValue({}),
+  removeCapita: vi.fn<(internalId: string) => Promise<void>>().mockResolvedValue(),
 }));

--- a/server/utils/pax.ts
+++ b/server/utils/pax.ts
@@ -1,17 +1,5 @@
 import { captureException, setContext } from "@sentry/node";
-import {
-  description,
-  email,
-  flatten,
-  object,
-  pipe,
-  safeParse,
-  string,
-  ValiError,
-  type BaseIssue,
-  type BaseSchema,
-  type InferInput,
-} from "valibot";
+import { flatten, object, safeParse, ValiError, type BaseIssue, type BaseSchema } from "valibot";
 import { encodePacked, keccak256 } from "viem";
 
 import type { Address } from "@exactly/common/validation";
@@ -27,17 +15,16 @@ const associateIdSecret = process.env.PAX_ASSOCIATE_ID_KEY;
 
 const ASSOCIATE_ID_LENGTH = 10;
 
-export const CapitaRequest = object({
-  firstName: string(),
-  lastName: string(),
-  document: string(),
-  birthdate: string(),
-  email: pipe(string(), email()),
-  phone: string(),
-  product: pipe(string(), description("the product name to add the capita to")),
-});
-
-export async function addCapita(data: InferInput<typeof CapitaRequest> & { internalId: string }) {
+export async function addCapita(data: {
+  birthdate: string;
+  document: string;
+  email: string;
+  firstName: string;
+  internalId: string;
+  lastName: string;
+  phone: string;
+  product: string;
+}) {
   return await request(object({}), "/api/capita", data, "POST");
 }
 


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exactly/exa/pull/670">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic travel-insurance enrollment when a signature card is issued as an upgrade from a platinum card; improved upgrade detection.

* **Bug Fixes**
  * Card creation now proceeds reliably even if the external enrollment service fails or persona account is missing.

* **Tests**
  * Expanded tests for signature issuance, upgrade flows, error cases, and missing-account scenarios; updated mocks.

* **Chores**
  * Added a changeset for the upcoming patch and streamlined the travel-insurance integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->