### PR TITLE
⚰️ server: remove template id param

### DIFF
--- a/.changeset/swift-pigs-know.md
+++ b/.changeset/swift-pigs-know.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+⚰️ remove template id param

--- a/server/test/api/kyc.test.ts
+++ b/server/test/api/kyc.test.ts
@@ -305,17 +305,12 @@ describe("authenticated", () => {
         });
       });
 
-      it("returns OTL and session token when creating inquiry", async () => {
+      it("returns session token when creating inquiry", async () => {
         await database.update(credentials).set({ pandaId: null }).where(eq(credentials.id, "bob"));
 
-        const otl = "https://new-url.com";
         const sessionToken = "persona-session-token";
 
         vi.spyOn(persona, "getInquiry").mockResolvedValueOnce(undefined); // eslint-disable-line unicorn/no-useless-undefined
-        vi.spyOn(persona, "generateOTL").mockResolvedValueOnce({
-          ...OTLTemplate,
-          meta: { ...OTLTemplate.meta, "one-time-link": otl },
-        });
         vi.spyOn(persona, "resumeInquiry").mockResolvedValueOnce({
           ...resumeTemplate,
           meta: { ...resumeTemplate.meta, "session-token": sessionToken },
@@ -334,22 +329,15 @@ describe("authenticated", () => {
         expect(getPendingInquiryTemplate).toHaveBeenCalledWith("bob", "basic");
         expect(createInquiry).toHaveBeenCalledWith("bob", persona.PANDA_TEMPLATE, undefined);
         await expect(response.json()).resolves.toStrictEqual({
-          otl,
           sessionToken,
-          legacy: otl,
           inquiryId: resumeTemplate.data.id,
         });
         expect(response.status).toBe(200);
       });
 
-      it("returns OTL link and session token when resuming created inquiry", async () => {
-        const otl = "https://resume-url.com";
+      it("returns session token when resuming created inquiry", async () => {
         const sessionToken = "persona-session-token";
 
-        vi.spyOn(persona, "generateOTL").mockResolvedValueOnce({
-          ...OTLTemplate,
-          meta: { ...OTLTemplate.meta, "one-time-link": otl },
-        });
         vi.spyOn(persona, "resumeInquiry").mockResolvedValueOnce({
           ...resumeTemplate,
           meta: { ...resumeTemplate.meta, "session-token": sessionToken },
@@ -369,22 +357,15 @@ describe("authenticated", () => {
         expect(getPendingInquiryTemplate).toHaveBeenCalledWith("bob", "basic");
         expect(getInquiry).toHaveBeenCalledWith("bob", persona.PANDA_TEMPLATE);
         await expect(response.json()).resolves.toStrictEqual({
-          otl,
           sessionToken,
-          legacy: otl,
           inquiryId: resumeTemplate.data.id,
         });
         expect(response.status).toBe(200);
       });
 
-      it("returns OTL link and session token when resuming pending inquiry", async () => {
-        const otl = "https://resume-url.com";
+      it("returns session token when resuming pending inquiry", async () => {
         const sessionToken = "persona-session-token";
 
-        vi.spyOn(persona, "generateOTL").mockResolvedValueOnce({
-          ...OTLTemplate,
-          meta: { ...OTLTemplate.meta, "one-time-link": otl },
-        });
         vi.spyOn(persona, "resumeInquiry").mockResolvedValueOnce({
           ...resumeTemplate,
           meta: { ...resumeTemplate.meta, "session-token": sessionToken },
@@ -404,22 +385,15 @@ describe("authenticated", () => {
         expect(getPendingInquiryTemplate).toHaveBeenCalledWith("bob", "basic");
         expect(getInquiry).toHaveBeenCalledWith("bob", persona.PANDA_TEMPLATE);
         await expect(response.json()).resolves.toStrictEqual({
-          otl,
           sessionToken,
-          legacy: otl,
           inquiryId: resumeTemplate.data.id,
         });
         expect(response.status).toBe(200);
       });
 
-      it("returns OTL link and session token when resuming expired inquiry", async () => {
-        const otl = "https://resume-url.com";
+      it("returns session token when resuming expired inquiry", async () => {
         const sessionToken = "persona-session-token";
 
-        vi.spyOn(persona, "generateOTL").mockResolvedValueOnce({
-          ...OTLTemplate,
-          meta: { ...OTLTemplate.meta, "one-time-link": otl },
-        });
         vi.spyOn(persona, "resumeInquiry").mockResolvedValueOnce({
           ...resumeTemplate,
           meta: { ...resumeTemplate.meta, "session-token": sessionToken },
@@ -439,9 +413,7 @@ describe("authenticated", () => {
         expect(getPendingInquiryTemplate).toHaveBeenCalledWith("bob", "basic");
         expect(getInquiry).toHaveBeenCalledWith("bob", persona.PANDA_TEMPLATE);
         await expect(response.json()).resolves.toStrictEqual({
-          otl,
           sessionToken,
-          legacy: otl,
           inquiryId: resumeTemplate.data.id,
         });
         expect(response.status).toBe(200);
@@ -879,17 +851,12 @@ describe("authenticated", () => {
         expect(response.status).toBe(400);
       });
 
-      it("returns otl and session token when creating manteca extra fields inquiry", async () => {
+      it("returns session token when creating manteca extra fields inquiry", async () => {
         await database.update(credentials).set({ pandaId: null }).where(eq(credentials.id, "bob"));
 
-        const otl = "https://new-manteca-url.com";
         const sessionToken = "manteca-session-token";
 
         vi.spyOn(persona, "getInquiry").mockResolvedValueOnce(undefined); // eslint-disable-line unicorn/no-useless-undefined
-        vi.spyOn(persona, "generateOTL").mockResolvedValueOnce({
-          ...OTLTemplate,
-          meta: { ...OTLTemplate.meta, "one-time-link": otl },
-        });
         vi.spyOn(persona, "resumeInquiry").mockResolvedValueOnce({
           ...resumeTemplate,
           meta: { ...resumeTemplate.meta, "session-token": sessionToken },
@@ -908,25 +875,18 @@ describe("authenticated", () => {
         expect(getPendingInquiryTemplate).toHaveBeenCalledWith("bob", "manteca");
         expect(createInquiry).toHaveBeenCalledWith("bob", persona.MANTECA_TEMPLATE_EXTRA_FIELDS, undefined);
         await expect(response.json()).resolves.toStrictEqual({
-          otl,
           sessionToken,
-          legacy: otl,
           inquiryId: resumeTemplate.data.id,
         });
         expect(response.status).toBe(200);
       });
 
-      it("returns otl and session token when creating manteca with id class inquiry", async () => {
+      it("returns session token when creating manteca with id class inquiry", async () => {
         await database.update(credentials).set({ pandaId: null }).where(eq(credentials.id, "bob"));
 
-        const otl = "https://new-manteca-id-url.com";
         const sessionToken = "manteca-id-session-token";
 
         vi.spyOn(persona, "getInquiry").mockResolvedValueOnce(undefined); // eslint-disable-line unicorn/no-useless-undefined
-        vi.spyOn(persona, "generateOTL").mockResolvedValueOnce({
-          ...OTLTemplate,
-          meta: { ...OTLTemplate.meta, "one-time-link": otl },
-        });
         vi.spyOn(persona, "resumeInquiry").mockResolvedValueOnce({
           ...resumeTemplate,
           meta: { ...resumeTemplate.meta, "session-token": sessionToken },
@@ -945,22 +905,15 @@ describe("authenticated", () => {
         expect(getPendingInquiryTemplate).toHaveBeenCalledWith("bob", "manteca");
         expect(createInquiry).toHaveBeenCalledWith("bob", persona.MANTECA_TEMPLATE_WITH_ID_CLASS, undefined);
         await expect(response.json()).resolves.toStrictEqual({
-          otl,
           sessionToken,
-          legacy: otl,
           inquiryId: resumeTemplate.data.id,
         });
         expect(response.status).toBe(200);
       });
 
-      it("returns otl and session token when resuming pending manteca inquiry", async () => {
-        const otl = "https://resume-manteca-url.com";
+      it("returns session token when resuming pending manteca inquiry", async () => {
         const sessionToken = "resume-manteca-session-token";
 
-        vi.spyOn(persona, "generateOTL").mockResolvedValueOnce({
-          ...OTLTemplate,
-          meta: { ...OTLTemplate.meta, "one-time-link": otl },
-        });
         vi.spyOn(persona, "resumeInquiry").mockResolvedValueOnce({
           ...resumeTemplate,
           meta: { ...resumeTemplate.meta, "session-token": sessionToken },
@@ -981,9 +934,7 @@ describe("authenticated", () => {
         expect(getPendingInquiryTemplate).toHaveBeenCalledWith("bob", "manteca");
         expect(getInquiry).toHaveBeenCalledWith("bob", persona.MANTECA_TEMPLATE_EXTRA_FIELDS);
         await expect(response.json()).resolves.toStrictEqual({
-          otl,
           sessionToken,
-          legacy: otl,
           inquiryId: resumeTemplate.data.id,
         });
         expect(response.status).toBe(200);
@@ -1034,139 +985,6 @@ describe("authenticated", () => {
           contexts: { inquiry: { templateId: persona.MANTECA_TEMPLATE_EXTRA_FIELDS, referenceId: "bob" } },
         });
       });
-    });
-  });
-
-  describe("legacy kyc flow", () => {
-    it("returns ok kyc approved with country code", async () => {
-      await database.update(credentials).set({ pandaId: "pandaId" }).where(eq(credentials.id, "bob"));
-      const getInquiry = vi.spyOn(persona, "getInquiry");
-      const getAccount = vi
-        .spyOn(persona, "getAccount")
-        .mockResolvedValueOnce(basicAccount as persona.AccountOutput<"basic">);
-
-      const response = await appClient.index.$get(
-        { query: { countryCode: "true" } },
-        { headers: { "test-credential-id": "bob", SessionID: "fakeSession" } },
-      );
-
-      expect(getAccount).toHaveBeenCalledOnce();
-      expect(getInquiry).not.toHaveBeenCalled();
-      await expect(response.json()).resolves.toStrictEqual({ code: "ok", legacy: "ok" });
-      expect(response.headers.get("User-Country")).toBe("AR");
-      expect(response.status).toBe(200);
-    });
-
-    it("returns ok kyc approved when panda id is present", async () => {
-      await database.update(credentials).set({ pandaId: "pandaId" }).where(eq(credentials.id, "bob"));
-      const getInquiry = vi.spyOn(persona, "getInquiry");
-      const getAccount = vi.spyOn(persona, "getAccount");
-
-      const response = await appClient.index.$get(
-        { query: {} },
-        { headers: { "test-credential-id": "bob", SessionID: "fakeSession" } },
-      );
-
-      expect(getAccount).not.toHaveBeenCalled();
-      expect(getInquiry).not.toHaveBeenCalled();
-      await expect(response.json()).resolves.toStrictEqual({ code: "ok", legacy: "ok" });
-      expect(response.status).toBe(200);
-    });
-
-    it("resumes inquiry with template", async () => {
-      await database.update(credentials).set({ pandaId: null }).where(eq(credentials.id, "bob"));
-      const templateId = persona.PANDA_TEMPLATE;
-      const getInquiry = vi.spyOn(persona, "getInquiry").mockResolvedValueOnce({
-        ...personaTemplate,
-        attributes: { ...personaTemplate.attributes, status: "pending" },
-      });
-      const resumeInquiry = vi.spyOn(persona, "resumeInquiry").mockResolvedValueOnce(resumeTemplate);
-
-      const response = await appClient.index.$get(
-        { query: { templateId } },
-        { headers: { "test-credential-id": "bob", SessionID: "fakeSession" } },
-      );
-
-      expect(getInquiry).toHaveBeenCalledWith("bob", templateId);
-      expect(resumeInquiry).toHaveBeenCalledWith(resumeTemplate.data.id);
-      await expect(response.json()).resolves.toStrictEqual({
-        inquiryId: resumeTemplate.data.id,
-        sessionToken: resumeTemplate.meta["session-token"],
-      });
-      expect(response.status).toBe(200);
-    });
-
-    it("returns OTL and session token when creating inquiry", async () => {
-      await database.update(credentials).set({ pandaId: null }).where(eq(credentials.id, "bob"));
-
-      const otl = "https://new-url.com";
-      const sessionToken = "persona-session-token";
-
-      vi.spyOn(persona, "generateOTL").mockResolvedValueOnce({
-        ...OTLTemplate,
-        meta: { ...OTLTemplate.meta, "one-time-link": otl },
-      });
-      vi.spyOn(persona, "resumeInquiry").mockResolvedValueOnce({
-        ...resumeTemplate,
-        meta: { ...resumeTemplate.meta, "session-token": sessionToken },
-      });
-      vi.spyOn(persona, "getInquiry").mockResolvedValueOnce(undefined); // eslint-disable-line unicorn/no-useless-undefined
-
-      const getPendingInquiryTemplate = vi
-        .spyOn(persona, "getPendingInquiryTemplate")
-        .mockResolvedValueOnce(persona.PANDA_TEMPLATE);
-      const createInquiry = vi.spyOn(persona, "createInquiry").mockResolvedValueOnce(OTLTemplate);
-
-      const response = await appClient.index.$post(
-        { json: {} },
-        { headers: { "test-credential-id": "bob", SessionID: "fakeSession" } },
-      );
-
-      expect(getPendingInquiryTemplate).toHaveBeenCalledWith("bob", "basic");
-      expect(createInquiry).toHaveBeenCalledWith("bob", persona.PANDA_TEMPLATE, undefined);
-      await expect(response.json()).resolves.toStrictEqual({
-        otl,
-        sessionToken,
-        legacy: otl,
-        inquiryId: resumeTemplate.data.id,
-      });
-      expect(response.status).toBe(200);
-    });
-
-    it("returns OTL link and session token when resuming inquiry", async () => {
-      const templateId = "template";
-      const otl = "https://resume-url.com";
-      const sessionToken = "persona-session-token";
-
-      vi.spyOn(persona, "generateOTL").mockResolvedValueOnce({
-        ...OTLTemplate,
-        meta: { ...OTLTemplate.meta, "one-time-link": otl },
-      });
-      vi.spyOn(persona, "resumeInquiry").mockResolvedValueOnce({
-        ...resumeTemplate,
-        meta: { ...resumeTemplate.meta, "session-token": sessionToken },
-      });
-      const getPendingInquiryTemplate = vi
-        .spyOn(persona, "getPendingInquiryTemplate")
-        .mockResolvedValueOnce(persona.PANDA_TEMPLATE);
-      const getInquiry = vi.spyOn(persona, "getInquiry").mockResolvedValueOnce({
-        ...personaTemplate,
-        attributes: { ...personaTemplate.attributes, status: "created" },
-      });
-      const response = await appClient.index.$post(
-        { json: { templateId } },
-        { headers: { "test-credential-id": "bob" } },
-      );
-
-      expect(getPendingInquiryTemplate).toHaveBeenCalledWith("bob", "basic");
-      expect(getInquiry).toHaveBeenCalledWith("bob", persona.PANDA_TEMPLATE);
-      await expect(response.json()).resolves.toStrictEqual({
-        otl,
-        sessionToken,
-        legacy: otl,
-        inquiryId: resumeTemplate.data.id,
-      });
-      expect(response.status).toBe(200);
     });
   });
 });
@@ -1435,21 +1253,6 @@ const resumeTemplate = {
   },
   meta: {
     "session-token": "fakeSession",
-  },
-} as const;
-
-const OTLTemplate = {
-  data: {
-    attributes: {
-      status: "created",
-      "reference-id": "ref-123",
-    },
-    id: "test-id",
-    type: "inquiry",
-  },
-  meta: {
-    "one-time-link": "a link",
-    "one-time-link-short": "",
   },
 } as const;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed template-ID branching and one-time-link/legacy propagation; API now consistently returns only inquiry ID and session token
  * Deleted legacy inquiry utilities and related public artifacts

* **Tests**
  * Updated tests to expect only inquiry ID and session token; removed OTL/legacy assertions and related test blocks

* **Chores**
  * Added a changeset documenting the patch update

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exactly/exa/pull/692">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
