### PR TITLE
✨ server: validate id document photos for manteca

### DIFF
--- a/.changeset/gentle-streets-attack.md
+++ b/.changeset/gentle-streets-attack.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+✨ validate id document photos for manteca

--- a/server/utils/ramps/manteca.ts
+++ b/server/utils/ramps/manteca.ts
@@ -242,7 +242,7 @@ export async function mantecaOnboarding(account: Address, credentialId: string) 
   if (!personaAccount) throw new Error(ErrorCodes.NO_PERSONA_ACCOUNT);
   const countryCode = personaAccount.attributes["country-code"];
 
-  const identityDocument = getDocumentForManteca(personaAccount.attributes.fields.documents.value, countryCode);
+  const identityDocument = await getDocumentForManteca(personaAccount.attributes.fields.documents.value, countryCode);
   if (!identityDocument) {
     captureException(new Error("no identity document"), {
       level: "error",


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exactly/exa/pull/693">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ID document photo validation added to Manteca onboarding to ensure required front/back photos and country-specific rules are respected.

* **Refactor**
  * Account evaluation and document-selection flows converted to async and now prioritize valid ID types per country and photo-side requirements.

* **Tests**
  * Expanded test coverage for Manteca scenarios, async flows, network/chain cases, and document retrieval/validation behaviors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->