### PR TITLE
🥅 server: add retry to identity file upload

### DIFF
--- a/.changeset/pretty-badgers-cheat.md
+++ b/.changeset/pretty-badgers-cheat.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+🥅 add retry to identity file upload


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exactly/exa/pull/700">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Identity file uploads now include automatic retry behavior with short delays and limited attempts, improving reliability during transient network errors.

* **Tests**
  * Added end-to-end tests covering retry success, max-retry failure, network errors, and presigned URL failure scenarios to ensure upload robustness.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->