### PR TITLE
🐛 server: select valid document when multiple same-class ids exist

### DIFF
--- a/.changeset/ripe-oranges-vanish.md
+++ b/.changeset/ripe-oranges-vanish.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+🐛 select valid document when multiple same-class ids exist


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exactly/exa/pull/706">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed document selection to properly choose the correct document when multiple documents with the same class ID exist.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->