### PR TITLE
✨ server: add limits to ramp provider response

### DIFF
--- a/.changeset/thin-boxes-carry.md
+++ b/.changeset/thin-boxes-carry.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+✨ add limits to ramp provider response

--- a/server/api/ramp.ts
+++ b/server/api/ramp.ts
@@ -93,7 +93,7 @@ export default new Hono()
         manteca: mantecaProvider,
         bridge: bridgeProvider,
       };
-      return c.json({ providers });
+      return c.json({ providers }, 200);
     },
   )
   .get(
@@ -140,7 +140,7 @@ export default new Hono()
             }
             throw error;
           }
-          return c.json({ quote: await getMantecaQuote(`USDC_${query.currency}`), depositInfo });
+          return c.json({ quote: await getMantecaQuote(`USDC_${query.currency}`), depositInfo }, 200);
         }
         case "bridge": {
           if (!credential.bridgeId) return c.json({ code: ErrorCodes.NOT_STARTED }, 400);
@@ -162,10 +162,13 @@ export default new Hono()
             throw error;
           }
 
-          return c.json({
-            quote: "currency" in query ? await getBridgeQuote(query.currency, query.currency) : undefined,
-            depositInfo,
-          });
+          return c.json(
+            {
+              quote: "currency" in query ? await getBridgeQuote(query.currency, query.currency) : undefined,
+              depositInfo,
+            },
+            200,
+          );
         }
       }
     },
@@ -226,6 +229,6 @@ export default new Hono()
           }
           break;
       }
-      return c.json({ code: "ok" });
+      return c.json({ code: "ok" }, 200);
     },
   );

--- a/server/utils/ramps/shared.ts
+++ b/server/utils/ramps/shared.ts
@@ -125,6 +125,24 @@ export const PendingTask = variant("type", [
 export const ProviderInfo = object({
   onramp: object({
     currencies: array(string()),
+    limits: optional(
+      object({
+        monthly: optional(
+          object({
+            available: optional(string()),
+            limit: optional(string()),
+            symbol: string(),
+          }),
+        ),
+        yearly: optional(
+          object({
+            available: optional(string()),
+            limit: optional(string()),
+            symbol: string(),
+          }),
+        ),
+      }),
+    ),
     cryptoCurrencies: array(object({ cryptoCurrency: picklist(Cryptocurrency), network: picklist(CryptoNetwork) })),
   }),
   status: picklist(["NOT_STARTED", "ACTIVE", "ONBOARDING", "NOT_AVAILABLE"]),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ramp provider responses may now include optional monthly and yearly exchange limits (available amounts, caps, currency).

* **Bug Fixes**
  * API responses now explicitly return success status codes for ramp-related endpoints to ensure consistent client handling.

* **Tests**
  * Added and expanded tests covering onramp limits scenarios, edge cases, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exactly/exa/pull/723" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
