### PR TITLE
🥅 server: skip sentry capture for expected liquidity errors

### DIFF
--- a/.changeset/many-streets-travel.md
+++ b/.changeset/many-streets-travel.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+🥅 skip sentry capture for expected liquidity errors


### PR DESCRIPTION
closes #663 
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exactly/exa/pull/727" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
