### PR TITLE
🦺 server: handle optional panda wallets field

### DIFF
--- a/.changeset/mighty-guests-knock.md
+++ b/.changeset/mighty-guests-knock.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+🦺 handle optional panda wallets field

--- a/server/hooks/panda.ts
+++ b/server/hooks/panda.ts
@@ -168,7 +168,7 @@ const Payload = v.variant("resource", [
         ]),
       }),
       status: v.picklist(["notActivated", "active", "locked", "canceled"]),
-      tokenWallets: v.union([v.array(v.literal("Apple")), v.array(v.literal("Google Pay"))]),
+      tokenWallets: v.optional(v.union([v.array(v.literal("Apple")), v.array(v.literal("Google Pay"))])),
       type: v.literal("virtual"),
       userId: v.string(),
     }),


### PR DESCRIPTION
sentry issue: [SERVER-CH](https://exactly.sentry.io/issues/7102438183/)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exactly/exa/pull/728" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Payment wallet field is now optional, improving flexibility for payment configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->