### PR TITLE
♻️ server: flatten ramp providers response

### DIFF
--- a/.changeset/open-clowns-listen.md
+++ b/.changeset/open-clowns-listen.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+♻️ flatten ramp providers response

--- a/server/api/ramp.ts
+++ b/server/api/ramp.ts
@@ -89,11 +89,13 @@ export default new Hono()
         }),
       ]);
 
-      const providers: Record<(typeof RampProvider)[number], InferInput<typeof ProviderInfo>> = {
-        manteca: mantecaProvider,
-        bridge: bridgeProvider,
-      };
-      return c.json({ providers }, 200);
+      return c.json(
+        {
+          manteca: mantecaProvider,
+          bridge: bridgeProvider,
+        } satisfies Record<(typeof RampProvider)[number], InferInput<typeof ProviderInfo>>,
+        200,
+      );
     },
   )
   .get(

--- a/server/test/api/ramp.test.ts
+++ b/server/test/api/ramp.test.ts
@@ -63,10 +63,8 @@ describe("ramp api", () => {
       expect(response.status).toBe(200);
       const json = await response.json();
       expect(json).toStrictEqual({
-        providers: {
-          manteca: { onramp: { currencies: ["ARS", "USD"], cryptoCurrencies: [] }, status: "NOT_STARTED" },
-          bridge: { onramp: { currencies: [], cryptoCurrencies: [] }, status: "NOT_AVAILABLE" },
-        },
+        manteca: { onramp: { currencies: ["ARS", "USD"], cryptoCurrencies: [] }, status: "NOT_STARTED" },
+        bridge: { onramp: { currencies: [], cryptoCurrencies: [] }, status: "NOT_AVAILABLE" },
       });
     });
 
@@ -82,10 +80,8 @@ describe("ramp api", () => {
       expect(response.status).toBe(200);
       const json = await response.json();
       expect(json).toStrictEqual({
-        providers: {
-          manteca: { onramp: { currencies: [], cryptoCurrencies: [] }, status: "NOT_AVAILABLE" },
-          bridge: { onramp: { currencies: [], cryptoCurrencies: [] }, status: "NOT_AVAILABLE" },
-        },
+        manteca: { onramp: { currencies: [], cryptoCurrencies: [] }, status: "NOT_AVAILABLE" },
+        bridge: { onramp: { currencies: [], cryptoCurrencies: [] }, status: "NOT_AVAILABLE" },
       });
     });
 
@@ -101,10 +97,8 @@ describe("ramp api", () => {
       expect(response.status).toBe(200);
       const json = await response.json();
       expect(json).toStrictEqual({
-        providers: {
-          manteca: { onramp: { currencies: ["ARS"], cryptoCurrencies: [] }, status: "ACTIVE" },
-          bridge: { onramp: { currencies: [], cryptoCurrencies: [] }, status: "NOT_AVAILABLE" },
-        },
+        manteca: { onramp: { currencies: ["ARS"], cryptoCurrencies: [] }, status: "ACTIVE" },
+        bridge: { onramp: { currencies: [], cryptoCurrencies: [] }, status: "NOT_AVAILABLE" },
       });
     });
   });


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exactly/exa/pull/731" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the ramp providers API response to remove an unnecessary nesting level, returning provider entries at the top level for simpler consumption.

* **Tests**
  * Adjusted API tests to match the new, flattened response shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->