### PR TITLE
🥅 server: decode external swap errors in proposal execution

### DIFF
--- a/.changeset/red-tigers-accept.md
+++ b/.changeset/red-tigers-accept.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+🥅 decode external swap errors in proposal execution


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exactly/exa/pull/741" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved decoding and fingerprinting of errors during proposal execution to surface external swap failures (expired transactions, insufficient output, minimal output balance violations, and wrapped/inner errors).
* **Tests**
  * Added tests covering wrapped/inner error scenarios and fingerprinting behavior.
* **Chores**
  * Recorded a patch release entry noting the error-decoding improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->