### PR TITLE
🥅 server: fingerprint keeper errors for sentry grouping

### DIFF
--- a/.changeset/bright-foxes-catch.md
+++ b/.changeset/bright-foxes-catch.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+🥅 fingerprint keeper errors for sentry grouping

--- a/server/hooks/block.ts
+++ b/server/hooks/block.ts
@@ -357,7 +357,7 @@ function scheduleMessage(message: string) {
               ...(error instanceof BaseError && error.cause instanceof ContractFunctionRevertedError
                 ? error.cause.data?.errorName === "WrappedError" && error.cause.data.args
                   ? ["WrappedError", String(error.cause.data.args[1])]
-                  : [error.cause.reason ?? error.cause.data?.errorName ?? error.cause.signature ?? "unknown"]
+                  : [error.cause.data?.errorName ?? error.cause.reason ?? error.cause.signature ?? "unknown"]
                 : ["unknown"]),
             ],
           });

--- a/server/hooks/panda.ts
+++ b/server/hooks/panda.ts
@@ -385,8 +385,8 @@ export default new Hono().post(
                 fingerprint: [
                   "{{ default }}",
                   contractError.cause instanceof ContractFunctionRevertedError
-                    ? (contractError.cause.reason ??
-                      contractError.cause.data?.errorName ??
+                    ? (contractError.cause.data?.errorName ??
+                      contractError.cause.reason ??
                       contractError.cause.signature ??
                       "unknown")
                     : "unknown",

--- a/server/test/hooks/activity.test.ts
+++ b/server/test/hooks/activity.test.ts
@@ -100,7 +100,7 @@ describe("address activity", () => {
 
     expect(captureException).toHaveBeenCalledWith(
       new WaitForTransactionReceiptTimeoutError({ hash: zeroHash }),
-      expect.anything(),
+      expect.objectContaining({ level: "error", fingerprint: ["{{ default }}", "unknown"] }),
     );
 
     expect(response.status).toBe(200);

--- a/server/test/hooks/panda.test.ts
+++ b/server/test/hooks/panda.test.ts
@@ -314,7 +314,7 @@ describe("card operations", () => {
         expect(captureException).toHaveBeenCalledWith(
           expect.objectContaining({ name: "ContractFunctionExecutionError", functionName: "collectCredit" }),
           expect.objectContaining({
-            fingerprint: ["{{ default }}", "Arithmetic operation resulted in underflow or overflow."],
+            fingerprint: ["{{ default }}", "Panic"],
           }),
         );
         expect(captureException).toHaveBeenCalledWith(
@@ -631,7 +631,7 @@ describe("card operations", () => {
         expect(captureException).toHaveBeenNthCalledWith(
           1,
           new Error("timeout"),
-          expect.objectContaining({ level: "error" }),
+          expect.objectContaining({ level: "error", fingerprint: ["{{ default }}", "unknown"] }),
         );
         expect(captureException).toHaveBeenNthCalledWith(
           2,
@@ -670,7 +670,7 @@ describe("card operations", () => {
         expect(captureException).toHaveBeenNthCalledWith(
           1,
           expect.any(BaseError),
-          expect.objectContaining({ level: "error" }),
+          expect.objectContaining({ level: "error", fingerprint: ["{{ default }}", "unknown"] }),
         );
         expect(captureException).toHaveBeenNthCalledWith(
           2,
@@ -700,7 +700,10 @@ describe("card operations", () => {
           },
         });
 
-        expect(captureException).toHaveBeenCalledWith(new Error("Unexpected Error"), expect.anything());
+        expect(captureException).toHaveBeenCalledWith(
+          new Error("Unexpected Error"),
+          expect.objectContaining({ level: "error", fingerprint: ["{{ default }}", "unknown"] }),
+        );
         expect(response.status).toBe(569);
       });
 

--- a/server/test/utils/keeper.test.ts
+++ b/server/test/utils/keeper.test.ts
@@ -48,6 +48,10 @@ describe("fault tolerance", () => {
         { onHash },
       ),
     ).rejects.toThrow("Timed out while waiting for transaction");
+    expect(captureException).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "WaitForTransactionReceiptTimeoutError" }),
+      expect.objectContaining({ level: "error", fingerprint: ["{{ default }}", "unknown"] }),
+    );
     expect(onHash).toHaveBeenCalledOnce();
     expect(sendRawTransaction).toHaveBeenCalledTimes(3);
   });

--- a/server/utils/keeper.ts
+++ b/server/utils/keeper.ts
@@ -181,7 +181,15 @@ export function extender(keeper: WalletClient<HttpTransport, typeof chain, Priva
               }
             }
             span.setStatus({ code: SPAN_STATUS_ERROR, message: reason });
-            captureException(error, { level: "error" });
+            captureException(error, {
+              level: "error",
+              fingerprint: [
+                "{{ default }}",
+                error instanceof BaseError && error.cause instanceof ContractFunctionRevertedError
+                  ? (error.cause.data?.errorName ?? error.cause.reason ?? error.cause.signature ?? "unknown")
+                  : "unknown",
+              ],
+            });
             throw error;
           }
         }),


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exactly/exa/pull/743" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error grouping and reporting for contract-related failures and timeouts — error reports now include richer fingerprints to enable better grouping and clearer Sentry-style diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->