### PR TITLE
🦺 server: acknowledge panda dispute events

### DIFF
--- a/.changeset/neat-eel-walk.md
+++ b/.changeset/neat-eel-walk.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+🦺 acknowledge panda dispute events

--- a/server/hooks/panda.ts
+++ b/server/hooks/panda.ts
@@ -190,6 +190,12 @@ const Payload = v.variant("resource", [
   Transaction,
   Card,
   v.object({
+    resource: v.literal("dispute"),
+    action: v.string(),
+    body: v.looseObject({ id: v.string() }),
+    id: v.string(),
+  }),
+  v.object({
     resource: v.literal("user"),
     action: v.literal("updated"),
     body: v.object({
@@ -219,6 +225,7 @@ export default new Hono().post(
     getActiveSpan()?.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_OP, `panda.${payload.resource}.${payload.action}`);
 
     if (payload.resource !== "transaction") {
+      if (payload.resource === "dispute") return c.json({ code: "ok" });
       const pandaId =
         payload.resource === "card"
           ? payload.action === "updated"

--- a/server/test/hooks/panda.test.ts
+++ b/server/test/hooks/panda.test.ts
@@ -1363,6 +1363,22 @@ describe("card notification", () => {
   });
 });
 
+describe("dispute", () => {
+  it("returns ok", async () => {
+    const response = await appClient.index.$post({
+      header: { signature: "panda-signature" },
+      json: {
+        resource: "dispute",
+        action: "created",
+        body: { id: "dispute-id", status: "pending", transactionId: "tx-id" },
+        id: "webhook-id",
+      },
+    });
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ code: "ok" });
+  });
+});
+
 describe("concurrency", () => {
   let owner2: WalletClient<ReturnType<typeof http>, typeof chain, ReturnType<typeof privateKeyToAccount>>;
   let account2: Address;


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exactly/exa/pull/755" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for receiving and acknowledging dispute events from Panda (handler now immediately returns OK for dispute payloads).

* **Tests**
  * Added test coverage asserting dispute webhook events are accepted and return { code: "ok" }.

* **Chores**
  * Added a changeset entry with a patch bump and release note.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->