### PR TITLE
🥅 server: skip retries for replay reverts

### DIFF
--- a/.changeset/silent-streets-jump.md
+++ b/.changeset/silent-streets-jump.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+🥅 skip retries for replay reverts

--- a/server/hooks/panda.ts
+++ b/server/hooks/panda.ts
@@ -548,6 +548,14 @@ export default new Hono().post(
             }
             return c.json({ code: "ok" });
           } catch (error: unknown) {
+            if (
+              error instanceof BaseError &&
+              error.cause instanceof ContractFunctionRevertedError &&
+              error.cause.data?.errorName === "Replay"
+            ) {
+              getActiveSpan()?.setAttributes({ "panda.replay": true, "panda.transaction": payload.body.id });
+              return c.json({ code: "ok" });
+            }
             captureException(error, { level: "fatal", tags: { unhandled: true } });
             return c.json(
               { code: error instanceof Error ? error.message : String(error) },
@@ -721,6 +729,14 @@ export default new Hono().post(
             }
             return c.json({ code: "ok" });
           } catch (error: unknown) {
+            if (
+              error instanceof BaseError &&
+              error.cause instanceof ContractFunctionRevertedError &&
+              error.cause.data?.errorName === "Replay"
+            ) {
+              getActiveSpan()?.setAttributes({ "panda.replay": true, "panda.transaction": payload.body.id });
+              return c.json({ code: "ok" });
+            }
             captureException(error, { level: "fatal", contexts: { tx: { call } } });
             if (payload.action === "completed") {
               const tx = await database.query.transactions.findFirst({

--- a/server/test/hooks/panda.test.ts
+++ b/server/test/hooks/panda.test.ts
@@ -681,6 +681,34 @@ describe("card operations", () => {
         expect(response.status).toBe(569);
       });
 
+      it("returns ok on replay", async () => {
+        const cardId = "replay-collect";
+        await database.insert(cards).values([{ id: cardId, credentialId: "cred", lastFour: "9999", mode: 0 }]);
+
+        const json = {
+          ...authorization.json,
+          action: "created" as const,
+          body: {
+            ...authorization.json.body,
+            id: cardId,
+            spend: { ...authorization.json.body.spend, cardId, amount: 50 },
+          },
+        };
+
+        const first = await appClient.index.$post({ ...authorization, json });
+        const tx = await database.query.transactions.findFirst({ where: eq(transactions.id, cardId) });
+        await publicClient.waitForTransactionReceipt({ hash: tx?.hashes[0] as Hex, confirmations: 0 });
+        expect(first.status).toBe(200);
+
+        const second = await appClient.index.$post({ ...authorization, json });
+
+        expect(second.status).toBe(200);
+        expect(captureException).toHaveBeenCalledExactlyOnceWith(
+          expect.any(BaseError),
+          expect.objectContaining({ level: "error", fingerprint: ["{{ default }}", "Replay"] }),
+        );
+      });
+
       it("fails with unexpected error", async () => {
         vi.spyOn(publicClient, "simulateContract").mockRejectedValue(new Error("Unexpected Error"));
 
@@ -815,6 +843,61 @@ describe("card operations", () => {
 
         expect(deposit?.args.assets).toBe(BigInt(amount * 1e4));
         expect(response.status).toBe(200);
+      });
+
+      it("returns ok on reversal replay", async () => {
+        const amount = 1500;
+        const cardId = "reversal-replay";
+        await database.insert(cards).values([{ id: cardId, credentialId: "cred", lastFour: "3333" }]);
+
+        const createdAt = new Date();
+        await appClient.index.$post({
+          ...authorization,
+          json: {
+            ...authorization.json,
+            action: "created",
+            body: {
+              ...authorization.json.body,
+              id: cardId,
+              spend: {
+                ...authorization.json.body.spend,
+                cardId,
+                amount,
+                localAmount: amount,
+                authorizedAt: createdAt.toISOString(),
+              },
+            },
+          },
+        });
+
+        const updatedJson = {
+          ...authorization.json,
+          action: "updated" as const,
+          body: {
+            ...authorization.json.body,
+            id: cardId,
+            spend: {
+              ...authorization.json.body.spend,
+              cardId,
+              authorizationUpdateAmount: -amount,
+              authorizedAt: new Date(createdAt.getTime() + 1000 * 30).toISOString(),
+              status: "reversed" as const,
+            },
+          },
+        };
+
+        const first = await appClient.index.$post({ ...authorization, json: updatedJson });
+        const tx = await database.query.transactions.findFirst({ where: eq(transactions.id, cardId) });
+        await publicClient.waitForTransactionReceipt({ hash: tx?.hashes[1] as Hex, confirmations: 0 });
+        expect(first.status).toBe(200);
+
+        const second = await appClient.index.$post({ ...authorization, json: updatedJson });
+
+        expect(second.status).toBe(200);
+        expect(captureException).toHaveBeenCalledExactlyOnceWith(
+          expect.any(BaseError),
+          expect.objectContaining({ level: "error", fingerprint: ["{{ default }}", "Replay"] }),
+        );
       });
 
       it("fails with spending transaction not found", async () => {


### PR DESCRIPTION
Panda sometimes doesn't care that we return 200 and the webhook retries again flooding our instrumetation so the PR is about preventing those retries to happen returning 200 only for Replay reverts 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of contract replay scenarios to prevent unnecessary error escalation, ensuring idempotent request processing and enhanced reliability in transaction operations.

* **Tests**
  * Added test coverage validating idempotent behavior for replayed requests in card creation, reversal, and refund flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->