### PR TITLE
🥅 server: skip retries for replay reverts

### DIFF
--- a/.changeset/silent-streets-jump.md
+++ b/.changeset/silent-streets-jump.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+🥅 skip retries for replay reverts

--- a/server/hooks/panda.ts
+++ b/server/hooks/panda.ts
@@ -548,6 +548,14 @@ export default new Hono().post(
             }
             return c.json({ code: "ok" });
           } catch (error: unknown) {
+            if (
+              error instanceof BaseError &&
+              error.cause instanceof ContractFunctionRevertedError &&
+              error.cause.data?.errorName === "Replay"
+            ) {
+              getActiveSpan()?.setAttributes({ "panda.replay": true });
+              return c.json({ code: "ok" });
+            }
             captureException(error, { level: "fatal", tags: { unhandled: true } });
             return c.json(
               { code: error instanceof Error ? error.message : String(error) },
@@ -721,6 +729,14 @@ export default new Hono().post(
             }
             return c.json({ code: "ok" });
           } catch (error: unknown) {
+            if (
+              error instanceof BaseError &&
+              error.cause instanceof ContractFunctionRevertedError &&
+              error.cause.data?.errorName === "Replay"
+            ) {
+              getActiveSpan()?.setAttributes({ "panda.replay": true });
+              return c.json({ code: "ok" });
+            }
             captureException(error, { level: "fatal", contexts: { tx: { call } } });
             if (payload.action === "completed") {
               const tx = await database.query.transactions.findFirst({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of replay reverts to skip retries and avoid unnecessary fatal error escalation, resulting in faster, more resilient transaction handling.

* **Tests**
  * Added end-to-end tests covering replay scenarios across card creation, reversal, and refund-related flows to ensure consistent replay behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exactly/exa/pull/758" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
