### PR TITLE
🥅 server: resolve orphaned proposals on nonce-too-low revert

### DIFF
--- a/.changeset/brave-foxes-camp.md
+++ b/.changeset/brave-foxes-camp.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+🥅 resolve orphaned proposals on nonce-too-low revert


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exactly/exa/pull/765" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Proposals no longer remain pending after nonce-too-low transaction reverts; orphaned proposals are now resolved and removed from processing.
* **Tests**
  * Test suite updated to assert cleanup behavior (treating nonce-too-low as a handled condition) and verify side-effect removal of pending proposals.
* **Chores**
  * Added changeset entry for the patch release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->