### PR TITLE
🥅 server: handle no-proposal as success in proposal execution

### DIFF
--- a/.changeset/brave-falcon-catch.md
+++ b/.changeset/brave-falcon-catch.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+🥅 handle no-proposal as success in proposal execution

--- a/server/hooks/block.ts
+++ b/server/hooks/block.ts
@@ -359,7 +359,7 @@ function scheduleMessage(message: string) {
           if (
             error instanceof BaseError &&
             error.cause instanceof ContractFunctionRevertedError &&
-            error.cause.data?.errorName === "NonceTooLow"
+            (error.cause.data?.errorName === "NonceTooLow" || error.cause.data?.errorName === "NoProposal")
           ) {
             parent.setStatus({ code: SPAN_STATUS_OK, message: "aborted" });
             return redis.zrem("proposals", message);


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exactly/exa/pull/772" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced error handling in proposal execution workflows to properly recognize and treat no-proposal errors as successful outcomes. This prevents unnecessary error reporting, reduces false failure notifications, and ensures accurate transaction queue management when proposals are unavailable, improving overall system reliability and transaction processing accuracy in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->