### PR TITLE
🥅 app: fingerprint passkey errors by message, drop expected ones

### DIFF
--- a/.changeset/nrts-fppm-tpur.md
+++ b/.changeset/nrts-fppm-tpur.md
@@ -1,0 +1,5 @@
+---
+"@exactly/mobile": patch
+---
+
+🥅 fingerprint passkey errors by message, drop expected ones

--- a/src/utils/accountClient.ts
+++ b/src/utils/accountClient.ts
@@ -61,6 +61,7 @@ import e2e from "./e2e";
 import { login } from "./onesignal";
 import publicClient from "./publicClient";
 import queryClient, { type AuthMethod } from "./queryClient";
+import { isPasskeyCancelled } from "./reportError";
 import ownerConfig from "./wagmi/owner";
 
 import type { Credential } from "@exactly/common/validation";
@@ -106,17 +107,7 @@ export default async function createAccountClient({ credentialId, factory, x, y 
         if (s > P256_N / 2n) s = P256_N - s; // pass malleability guard
         return webauthn({ authenticatorData, clientDataJSON, challengeIndex, typeIndex, r, s });
       } catch (error: unknown) {
-        if (
-          error instanceof Error &&
-          (error.message ===
-            "The operation couldn’t be completed. (com.apple.AuthenticationServices.AuthorizationError error 1001.)" ||
-            error.message ===
-              "The operation couldn’t be completed. (com.apple.AuthenticationServices.AuthorizationError error 1004.)" ||
-            error.message === "The operation couldn’t be completed. Device must be unlocked to perform request." ||
-            error.message === "UserCancelled")
-        ) {
-          return "0x";
-        }
+        if (isPasskeyCancelled(error)) return "0x";
         throw error;
       }
     },

--- a/src/utils/reportError.ts
+++ b/src/utils/reportError.ts
@@ -1,10 +1,124 @@
-import { captureException } from "@sentry/react-native";
+import { captureException, withScope } from "@sentry/react-native";
 
 export default function reportError(error: unknown, hint?: Parameters<typeof captureException>[1]) {
   console.error(error); // eslint-disable-line no-console
+  const classification = classify(parseError(error));
+  if (classification.expected) return;
   try {
-    return captureException(error, hint);
+    if (hint) {
+      const value = classification.fingerprint;
+      if (value === undefined) return captureException(error, hint);
+      let eventId: ReturnType<typeof captureException> | undefined;
+      withScope((scope) => {
+        scope.setFingerprint(value);
+        eventId = captureException(error, hint);
+      });
+      return eventId;
+    }
+    return captureException(
+      error,
+      classification.fingerprint ? { fingerprint: classification.fingerprint } : undefined,
+    );
   } catch (sentryError) {
     console.error(sentryError); // eslint-disable-line no-console
   }
+}
+
+const passkeyCancelledMessages = new Set([
+  "The operation couldn’t be completed. (com.apple.AuthenticationServices.AuthorizationError error 1001.)",
+  "The operation couldn’t be completed. (com.apple.AuthenticationServices.AuthorizationError error 1004.)",
+  "The operation couldn’t be completed. Device must be unlocked to perform request.",
+  "UserCancelled",
+]);
+const passkeyExpectedMessages = new Set([
+  ...passkeyCancelledMessages,
+  "The operation couldn’t be completed. Stolen Device Protection is enabled and biometry is required.",
+]);
+const authPrefixes = ["androidx.credentials.exceptions.domerrors.NotAllowedError"];
+type ParsedError = ReturnType<typeof parseError>;
+
+export function isPasskeyExpected(error: unknown) {
+  const classification = classify(parseError(error));
+  return classification.passkeyExpected || classification.passkeyNameExpected;
+}
+
+export function isPasskeyCancelled(error: unknown) {
+  return classify(parseError(error)).passkeyCancelled;
+}
+
+export function isAuthExpected(error: unknown) {
+  return classify(parseError(error)).authExpected;
+}
+
+export function isExpected(error: unknown) {
+  return classify(parseError(error)).expected;
+}
+
+export function fingerprint(error: unknown) {
+  return classify(parseError(error)).fingerprint;
+}
+
+export function classifyError(error: unknown) {
+  return classify(parseError(error));
+}
+
+function parseError(error: unknown) {
+  const code =
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    typeof error.code === "string" &&
+    error.code.length > 0
+      ? error.code
+      : undefined;
+  const name =
+    typeof error === "object" &&
+    error !== null &&
+    "name" in error &&
+    typeof error.name === "string" &&
+    error.name.length > 0
+      ? error.name
+      : undefined;
+  const message =
+    error instanceof Error
+      ? normalizeMessage(error.message)
+      : typeof error === "string"
+        ? normalizeMessage(error)
+        : typeof error === "object" &&
+            error !== null &&
+            "message" in error &&
+            typeof error.message === "string" &&
+            error.message.length > 0
+          ? normalizeMessage(error.message)
+          : undefined;
+  return { code, name, message };
+}
+
+function classify({ code, name, message }: ParsedError) {
+  const passkeyNameExpected = name === "NotAllowedError";
+  const passkeyCancelled = message !== undefined && passkeyCancelledMessages.has(message);
+  const passkeyExpected =
+    message !== undefined &&
+    (passkeyExpectedMessages.has(message) ||
+      message.includes("There is already a pending passkey request") ||
+      authPrefixes.some((prefix) => message.startsWith(prefix)));
+  const authExpected = passkeyExpected || passkeyNameExpected || message === "invalid operation";
+  const expected = passkeyExpected || message === "invalid operation";
+  const fingerprintMessage =
+    message?.startsWith("Calling the 'get' function has failed") ||
+    message?.startsWith("The operation couldn’t be completed.")
+      ? message
+      : undefined;
+  const value =
+    code !== undefined && code !== "ERR_UNKNOWN"
+      ? ["{{ default }}", code]
+      : fingerprintMessage === undefined
+        ? undefined
+        : ["{{ default }}", fingerprintMessage];
+  return { passkeyExpected, passkeyCancelled, passkeyNameExpected, authExpected, expected, fingerprint: value };
+}
+
+function normalizeMessage(message: string) {
+  const value = message.startsWith("Error: ") ? message.slice("Error: ".length) : message;
+  return value.trim();
 }

--- a/src/utils/server.ts
+++ b/src/utils/server.ts
@@ -14,6 +14,7 @@ import { Credential } from "@exactly/common/validation";
 import { login as loginIntercom, logout as logoutIntercom } from "./intercom";
 import { decrypt, decryptPIN, encryptPIN, session } from "./panda";
 import queryClient, { APIError, type AuthMethod } from "./queryClient";
+import { isPasskeyExpected } from "./reportError";
 import ownerConfig from "./wagmi/owner";
 
 import type { ExaAPI } from "@exactly/server/api"; // eslint-disable-line @nx/enforce-module-boundaries
@@ -61,19 +62,7 @@ queryClient.setQueryDefaults<number | undefined>(["auth"], {
     return parse(Auth, expires);
   },
   meta: {
-    suppressError: (error) =>
-      error instanceof ValiError ||
-      (error instanceof Error &&
-        (error.name === "NotAllowedError" ||
-          error.message === "UnknownError" ||
-          error.message ===
-            "The operation couldn’t be completed. (com.apple.AuthenticationServices.AuthorizationError error 1001.)" ||
-          error.message ===
-            "The operation couldn’t be completed. (com.apple.AuthenticationServices.AuthorizationError error 1004.)" ||
-          error.message === "The operation couldn’t be completed. Device must be unlocked to perform request." ||
-          error.message === "UserCancelled" ||
-          error.message.startsWith("androidx.credentials.exceptions.domerrors.NotAllowedError") ||
-          ("code" in error && error.code === "ERR_UNKNOWN"))),
+    suppressError: (error) => error instanceof ValiError || isPasskeyExpected(error),
   },
 });
 


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exactly/exa/pull/774" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fewer spurious error reports by suppressing known passkey/auth cancellation and other expected errors.
  * Improved detection of user-cancelled authentication so cancellations no longer surface as incidents.

* **Refactor**
  * Centralized error classification and fingerprinting to make error reporting more consistent across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->