### PR TITLE
🥅 server: handle terminal withdraw reverts

### DIFF
--- a/.changeset/steady-otter-handle.md
+++ b/.changeset/steady-otter-handle.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+🥅 handle terminal withdraw reverts


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exactly/exa/pull/777" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and handling of terminal withdrawal reverts so failed withdrawals are aborted and queued entries removed to prevent incomplete or repeated attempts.
  * Enhanced error classification for withdrawal failures to ensure operations stop on terminal conditions.

* **Tests**
  * Expanded coverage for withdrawal flows, keeper outcomes, revert/fingerprint scenarios, and queue state expectations.

* **Chores**
  * Added a changeset to bump the patch version noting terminal withdraw handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->