### PR TITLE
🥅 server: group api errors by specific reason

### DIFF
--- a/.changeset/lucky-wolves-balance.md
+++ b/.changeset/lucky-wolves-balance.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+🥅 group api errors by specific reason


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exactly/exa/pull/786" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API error grouping so related errors are grouped by specific reason
  * Normalized and standardized error message processing for more consistent responses
  * More robust error parsing and body handling to reduce misclassification of error events
<!-- end of auto-generated comment: release notes by coderabbit.ai -->