### PR TITLE
🥅 server: suppress no-balance until retries exhaust

### DIFF
--- a/.changeset/brisk-otter-filter.md
+++ b/.changeset/brisk-otter-filter.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+🥅 suppress no-balance until retries exhaust


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exactly/exa/pull/789" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of no balance errors with enhanced retry logic and error signaling
  * Operations continue processing when no balance conditions are encountered, rather than failing entirely

* **Tests**
  * Added comprehensive test coverage for no balance error scenarios and recovery behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->