### PR TITLE
🥅 server: handle timelocked proposal reverts

### DIFF
--- a/.changeset/brave-falcon-retry.md
+++ b/.changeset/brave-falcon-retry.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+🥅 handle timelocked proposal reverts


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exactly/exa/pull/805" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consolidated revert handling: errors are now categorized (aborted, rescheduled, retrying, failed), timelocked proposals are requeued with updated unlock/retry info, out-of-order proposals are rescheduled, and aborted proposals are cleanly removed.
* **Tests**
  * Added/updated tests for timelocked requeueing, rescheduling behavior, and adjusted warning vs. error expectations for out-of-order proposals.
* **Chores**
  * Added a changeset documenting the patch release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->