### PR TITLE
🥅 server: capture proposal reverts as warnings

### DIFF
--- a/.changeset/calm-eagles-warn.md
+++ b/.changeset/calm-eagles-warn.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+🥅 capture proposal reverts as warnings


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exactly/exa/pull/808" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable severity for transaction operations: set captures to "error", "warning", or suppress via static or dynamic rules.

* **Bug Fixes**
  * Certain proposal revert failures now generate warnings (not errors) to reduce noise and surface actionable issues.

* **Tests**
  * Expanded coverage for severity options, dynamic-level functions, suppression behavior, and updated expectations for warning vs error captures.

* **Chores**
  * Patch release metadata added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->