### PR TITLE
🐛 server: require identity-validation completion for ramp tracking

### DIFF
--- a/.changeset/ready-groups-beam.md
+++ b/.changeset/ready-groups-beam.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+🐛 require identity-validation completion for ramp tracking

--- a/server/hooks/manteca.ts
+++ b/server/hooks/manteca.ts
@@ -28,6 +28,7 @@ import {
   convertBalanceToUsdc,
   ErrorCodes,
   OrderStatus,
+  UserOnboardingTasks,
   UserStatus,
   withdrawBalance,
   WithdrawStatus,
@@ -66,6 +67,7 @@ const Payload = variant("event", [
           externalId: string(),
           exchange: string(),
           status: picklist(UserStatus),
+          onboarding: UserOnboardingTasks,
         }),
       }),
       transform((data) => ({ ...data, userExternalId: data.user.externalId })),
@@ -218,7 +220,11 @@ export default new Hono().post(
         }
         return c.json({ code: "ok" }, 200);
       case "USER_ONBOARDING_UPDATE":
-        if (payload.data.user.status === "ACTIVE") {
+        if (
+          payload.data.user.status === "ACTIVE" &&
+          payload.data.updatedTasks.includes("IDENTITY_VALIDATION") &&
+          payload.data.user.onboarding.IDENTITY_VALIDATION?.status === "COMPLETED"
+        ) {
           track({
             userId: account,
             event: "RampAccount",

--- a/server/test/hooks/manteca.test.ts
+++ b/server/test/hooks/manteca.test.ts
@@ -11,6 +11,7 @@ import deriveAddress from "@exactly/common/deriveAddress";
 
 import database, { credentials } from "../../database";
 import app from "../../hooks/manteca";
+import * as onesignal from "../../utils/onesignal";
 import * as manteca from "../../utils/ramps/manteca";
 import * as segment from "../../utils/segment";
 
@@ -448,8 +449,9 @@ describe("manteca hook", () => {
   });
 
   describe("when a user onboarding is updated", () => {
-    it("tracks RampAccount when user becomes active", async () => {
+    it("tracks and notifies when user is active and identity validation is completed", async () => {
       vi.spyOn(segment, "track").mockReturnValue();
+      const sendPushNotification = vi.spyOn(onesignal, "sendPushNotification");
       const payload = {
         event: "USER_ONBOARDING_UPDATE",
         data: {
@@ -461,6 +463,7 @@ describe("manteca hook", () => {
             externalId: userExternalId,
             exchange: "ARGENTINA",
             status: "ACTIVE",
+            onboarding: { IDENTITY_VALIDATION: { required: true, status: "COMPLETED" as const } },
           },
         },
       };
@@ -476,9 +479,16 @@ describe("manteca hook", () => {
         event: "RampAccount",
         properties: { provider: "manteca", source: null },
       });
+      expect(sendPushNotification).toHaveBeenCalledWith({
+        userId: account,
+        headings: { en: "Fiat onramp activated" },
+        contents: { en: "Your fiat onramp account has been activated" },
+      });
     });
 
-    it("returns ok for onboarding status", async () => {
+    it("does not track or notify when updated task is not identity validation", async () => {
+      vi.spyOn(segment, "track").mockReturnValue();
+      const sendPushNotification = vi.spyOn(onesignal, "sendPushNotification");
       const payload = {
         event: "USER_ONBOARDING_UPDATE",
         data: {
@@ -489,7 +499,8 @@ describe("manteca hook", () => {
             numberId: "456",
             externalId: userExternalId,
             exchange: "ARGENTINA",
-            status: "ONBOARDING",
+            status: "ACTIVE",
+            onboarding: { IDENTITY_VALIDATION: { required: true, status: "COMPLETED" as const } },
           },
         },
       };
@@ -500,6 +511,95 @@ describe("manteca hook", () => {
 
       expect(response.status).toBe(200);
       await expect(response.json()).resolves.toStrictEqual({ code: "ok" });
+      expect(segment.track).not.toHaveBeenCalled();
+      expect(sendPushNotification).not.toHaveBeenCalled();
+    });
+
+    it("does not track or notify when identity validation task is not completed", async () => {
+      vi.spyOn(segment, "track").mockReturnValue();
+      const sendPushNotification = vi.spyOn(onesignal, "sendPushNotification");
+      const payload = {
+        event: "USER_ONBOARDING_UPDATE",
+        data: {
+          updatedTasks: ["IDENTITY_VALIDATION"],
+          user: {
+            email: "test@example.com",
+            id: "user123",
+            numberId: "456",
+            externalId: userExternalId,
+            exchange: "ARGENTINA",
+            status: "ACTIVE",
+            onboarding: { IDENTITY_VALIDATION: { required: true, status: "IN_PROGRESS" as const } },
+          },
+        },
+      };
+      const response = await appClient.index.$post({
+        header: { "md-webhook-signature": createSignature(payload) },
+        json: payload as never,
+      });
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toStrictEqual({ code: "ok" });
+      expect(segment.track).not.toHaveBeenCalled();
+      expect(sendPushNotification).not.toHaveBeenCalled();
+    });
+
+    it("does not track or notify when identity validation is missing from onboarding", async () => {
+      vi.spyOn(segment, "track").mockReturnValue();
+      const sendPushNotification = vi.spyOn(onesignal, "sendPushNotification");
+      const payload = {
+        event: "USER_ONBOARDING_UPDATE",
+        data: {
+          updatedTasks: ["IDENTITY_VALIDATION"],
+          user: {
+            email: "test@example.com",
+            id: "user123",
+            numberId: "456",
+            externalId: userExternalId,
+            exchange: "ARGENTINA",
+            status: "ACTIVE",
+            onboarding: {},
+          },
+        },
+      };
+      const response = await appClient.index.$post({
+        header: { "md-webhook-signature": createSignature(payload) },
+        json: payload as never,
+      });
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toStrictEqual({ code: "ok" });
+      expect(segment.track).not.toHaveBeenCalled();
+      expect(sendPushNotification).not.toHaveBeenCalled();
+    });
+
+    it("does not track or notify when user status is not active", async () => {
+      vi.spyOn(segment, "track").mockReturnValue();
+      const sendPushNotification = vi.spyOn(onesignal, "sendPushNotification");
+      const payload = {
+        event: "USER_ONBOARDING_UPDATE",
+        data: {
+          updatedTasks: ["IDENTITY_VALIDATION"],
+          user: {
+            email: "test@example.com",
+            id: "user123",
+            numberId: "456",
+            externalId: userExternalId,
+            exchange: "ARGENTINA",
+            status: "ONBOARDING",
+            onboarding: { IDENTITY_VALIDATION: { required: true, status: "COMPLETED" as const } },
+          },
+        },
+      };
+      const response = await appClient.index.$post({
+        header: { "md-webhook-signature": createSignature(payload) },
+        json: payload as never,
+      });
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toStrictEqual({ code: "ok" });
+      expect(segment.track).not.toHaveBeenCalled();
+      expect(sendPushNotification).not.toHaveBeenCalled();
     });
   });
 });

--- a/server/utils/ramps/manteca.ts
+++ b/server/utils/ramps/manteca.ts
@@ -476,7 +476,7 @@ const OnboardingTaskInfo = optional(
     rejectionReason: optional(string()),
   }),
 );
-const UserOnboardingTasks = object({
+export const UserOnboardingTasks = object({
   EMAIL_VALIDATION: OnboardingTaskInfo,
   IDENTITY_DECLARATION: OnboardingTaskInfo,
   BASIC_PERSONAL_DATA_DEFINITION: OnboardingTaskInfo,


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ramp account tracking now only triggers when a user is active and identity validation is completed, preventing premature notifications.

* **Tests**
  * Expanded test coverage to validate both tracking and multiple non-tracking onboarding scenarios.

* **Chores**
  * Added a patch-level changeset and made the onboarding task schema publicly available for reuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exactly/exa/pull/812" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR correctly fixes the premature ramp-account tracking bug by adding three guard conditions to the `USER_ONBOARDING_UPDATE` handler:

- `user.status === "ACTIVE"`
- `updatedTasks` includes `"IDENTITY_VALIDATION"`  
- `onboarding.IDENTITY_VALIDATION.status === "COMPLETED"`

The changes are well-tested. Four new test cases cover every tracking scenario:
1. ✅ Tracking fires when all three conditions are met (user active, IDENTITY_VALIDATION in updatedTasks, status COMPLETED)
2. ✅ No tracking when updatedTasks doesn't include IDENTITY_VALIDATION
3. ✅ No tracking when IDENTITY_VALIDATION status is not COMPLETED  
4. ✅ No tracking when user status is not ACTIVE

The test at line 547 explicitly validates that tracking is suppressed when IDENTITY_VALIDATION is absent from the onboarding object, confirming the optional chaining works correctly.

`UserOnboardingTasks` is now exported from `server/utils/ramps/manteca.ts` to allow direct schema reuse in the hook layer.

<h3>Confidence Score: 5/5</h3>

- Safe to merge. The logic fix is correct with comprehensive test coverage, and all three guard conditions are properly implemented.
- The PR implements the correct fix with proper guard conditions (user active, IDENTITY_VALIDATION in updatedTasks, status COMPLETED). Test coverage is comprehensive, including all four scenarios: tracking enabled, and no-tracking for each individual guard condition failure. The code correctly uses optional chaining (?.) to handle missing IDENTITY_VALIDATION safely. No functional issues identified.
- No files require special attention.

<sub>Last reviewed commit: 3c1be87</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->