### PR TITLE
🐛 server: prefer latest document for manteca

### DIFF
--- a/.changeset/petite-days-ring.md
+++ b/.changeset/petite-days-ring.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+🐛 prefer latest document for manteca

--- a/server/utils/persona.ts
+++ b/server/utils/persona.ts
@@ -453,7 +453,7 @@ export async function getValidDocumentForManteca(
   for (const { id: idClass, side } of allowedIds) {
     const classDocuments = documents.filter(({ value: { id_class } }) => id_class.value === idClass);
     if (classDocuments.length === 0) continue;
-    for (const document of classDocuments) {
+    for (const document of classDocuments.toReversed()) {
       if (side === "front") return document.value;
       const { attributes } = await getDocument(document.value.id_document_id.value);
       if (attributes["front-photo"] && attributes["back-photo"]) {


### PR DESCRIPTION
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exactly/exa/pull/813" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

fixed document selection logic in `getValidDocumentForManteca` to prefer the latest document by reversing iteration order. when multiple documents of the same class exist (e.g., multiple ids), the function now checks the most recently added document first, falling back to earlier ones only if the latest is invalid.

- changed `server/utils/persona.ts:456` to iterate documents in reverse order using `.toReversed()`
- updated test expectations to reflect new behavior (now expects 1 fetch instead of 2 when latest document is valid)
- added new test cases covering latest document preference for both valid and fallback scenarios

<h3>Confidence Score: 5/5</h3>

- this pr is safe to merge with minimal risk
- the change is minimal (single method call), well-tested with comprehensive test coverage including edge cases, and the logic is straightforward. the fix correctly addresses the issue of preferring the latest document.
- no files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .changeset/petite-days-ring.md | standard changeset file documenting the bug fix |
| server/utils/persona.ts | added `.toReversed()` to prefer latest document when checking manteca eligibility |
| server/test/utils/persona.test.ts | updated and added tests to verify latest document preference behavior |

</details>



<sub>Last reviewed commit: 77098a5</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated document selection logic to prioritize the latest document version when multiple documents of the same class exist with valid photos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->