### PR TITLE
🐛 server: handle zero rate in panda activity response

### DIFF
--- a/.changeset/vdun-bohw-qwdu.md
+++ b/.changeset/vdun-bohw-qwdu.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+🐛 handle zero rate in panda activity response

--- a/server/api/activity.ts
+++ b/server/api/activity.ts
@@ -586,7 +586,7 @@ export const PandaActivity = pipe(
     } = details;
     const usdAmount = operations.reduce((sum, { usdAmount: amount }) => sum + amount, 0);
     const exchangeRate = flow.completed?.exchangeRate ?? [flow.created, ...flow.updates].at(-1)?.exchangeRate;
-    if (!exchangeRate) throw new Error("no exchange rate");
+    if (exchangeRate === undefined) throw new Error("no exchange rate");
     return {
       id,
       currency,

--- a/server/test/api/activity.test.ts
+++ b/server/test/api/activity.test.ts
@@ -194,6 +194,27 @@ describe.concurrent("authenticated", () => {
       await expect(response.json()).resolves.toStrictEqual(activity);
     });
 
+    it("accepts panda activity with zero exchange rate", () => {
+      const panda = safeParse(PandaActivity, {
+        type: "panda",
+        hashes: [zeroHash],
+        borrows: [null],
+        bodies: [
+          {
+            action: "created",
+            resource: "transaction",
+            createdAt: new Date(0).toISOString(),
+            body: { id: "zero-rate", type: "spend", spend: { ...spendTemplate, amount: 100, localAmount: 0 } },
+          },
+        ],
+      });
+
+      expect(panda.success).toBe(true);
+      if (!panda.success) return;
+      expect(panda.output.amount).toBe(0);
+      expect(panda.output.usdAmount).toBe(1);
+    });
+
     it("reports bad transaction", async () => {
       await database
         .insert(transactions)


### PR DESCRIPTION
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exactly/exa/pull/823" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

fixed a bug where zero exchange rates were incorrectly treated as missing values. the previous check `if (!exchangeRate)` would throw an error for `exchangeRate === 0`, which is a valid value when `localAmount` is zero. changed to `if (exchangeRate === undefined)` to only catch truly missing values.

- changed falsy check to explicit undefined check in `server/api/activity.ts:589`
- added test case for zero exchange rate scenario with `localAmount: 0`

<h3>Confidence Score: 5/5</h3>

- safe to merge - straightforward bug fix with appropriate test coverage
- the change correctly fixes a falsy value check that would incorrectly reject zero as a valid exchange rate. the fix is minimal (changing `!exchangeRate` to `exchangeRate === undefined`), follows javascript best practices for null/undefined checks, and includes a test case that validates the fix works correctly
- no files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/api/activity.ts | fixed falsy check to properly handle zero exchange rate values |
| server/test/api/activity.test.ts | added test coverage for zero exchange rate scenario |

</details>



<sub>Last reviewed commit: 67b9523</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of zero exchange rates in activity processing to prevent unexpected errors.

* **Tests**
  * Added test coverage for zero exchange rate scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->