### PR TITLE
🔒️ server: activate report-only csp for frontend assets

### DIFF
--- a/.changeset/new-owl-try.md
+++ b/.changeset/new-owl-try.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+🔒️ activate report-only csp for frontend assets

--- a/server/index.ts
+++ b/server/index.ts
@@ -3,6 +3,7 @@ import { serveStatic } from "@hono/node-server/serve-static";
 import { captureException, close as closeSentry } from "@sentry/node";
 import { isoBase64URL } from "@simplewebauthn/server/helpers";
 import { Hono } from "hono";
+import { secureHeaders } from "hono/secure-headers";
 import { trimTrailingSlash } from "hono/trailing-slash";
 
 import domain from "@exactly/common/domain";
@@ -87,7 +88,9 @@ app.get("/.well-known/farcaster.json", (c) =>
 );
 
 const frontend = new Hono();
-/*
+const reportUri = `https://o1351734.ingest.us.sentry.io/api/4506186349674496/security/?sentry_key=ac8875331e4cecd67dd0a7519a36dfeb&sentry_environment=${
+  { "web.exactly.app": "production" }[domain] ?? /^(.+)\.exactly\.app$/.exec(domain)?.[1] ?? domain
+}`;
 frontend.use(
   "/assets/*",
   secureHeaders({
@@ -100,15 +103,8 @@ frontend.use(
   secureHeaders({
     xFrameOptions: false,
     referrerPolicy: "strict-origin-when-cross-origin",
-    reportingEndpoints: [
-      {
-        name: "sentry",
-        url: `https://o1351734.ingest.us.sentry.io/api/4506186349674496/security/?sentry_key=ac8875331e4cecd67dd0a7519a36dfeb&sentry_environment=${
-          { "web.exactly.app": "production", "sandbox.exactly.app": "sandbox" }[domain] ?? domain
-        }`,
-      },
-    ],
-    contentSecurityPolicy: {
+    reportingEndpoints: [{ name: "sentry", url: reportUri }],
+    contentSecurityPolicyReportOnly: {
       defaultSrc: ["'self'"],
       styleSrc: ["'self'", "'unsafe-inline'", "https://onesignal.com"],
       scriptSrc: [
@@ -162,7 +158,7 @@ frontend.use(
         "'self'",
         // #region intercom https://www.intercom.com/help/en/articles/3894-using-intercom-with-content-security-policy
         "https://intercom-sheets.com",
-        "https://www.intercom-reporting.com ",
+        "https://www.intercom-reporting.com",
         "https://www.youtube.com",
         "https://player.vimeo.com",
         "https://fast.wistia.net",
@@ -209,7 +205,7 @@ frontend.use(
         "https://downloads.intercomcdn.eu",
         "https://downloads.au.intercomcdn.com",
         "https://uploads.intercomusercontent.com",
-        "https://gifs.intercomcdn.com ",
+        "https://gifs.intercomcdn.com",
         "https://video-messages.intercomcdn.com",
         "https://messenger-apps.intercom.io",
         "https://messenger-apps.eu.intercom.io",
@@ -242,10 +238,10 @@ frontend.use(
       objectSrc: ["'none'"],
       baseUri: ["'none'"],
       reportTo: "sentry",
+      reportUri,
     },
   }),
 );
-*/
 frontend.use(
   serveStatic({
     root: "app",


### PR DESCRIPTION
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exactly/exa/pull/825" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

activates content security policy in report-only mode for frontend assets, switching from enforcement to monitoring. this allows the team to observe csp violations without breaking functionality, facilitating a gradual rollout of security headers.

**key changes:**
- switched from `contentSecurityPolicy` to `contentSecurityPolicyReportOnly` to monitor violations without blocking
- uncommented previously disabled csp configuration block
- extracted `reportUri` as a standalone constant for reusability
- simplified environment mapping logic (removed explicit `sandbox.exactly.app` entry, now relies on regex pattern)
- cleaned up trailing whitespace in intercom urls
- added missing `reportUri` field alongside `reportTo` for broader browser support

**notes:**
- the csp policy includes `'unsafe-inline'` and `'unsafe-eval'` for scripts due to intercom requirements, which reduces security benefits but is documented as necessary
- environment mapping change should be verified against sentry configuration in `server/instrument.cjs`

<h3>Confidence Score: 4/5</h3>

- safe to merge with minor verification recommended
- the change safely activates csp in report-only mode rather than enforcement mode, which means it cannot break functionality. the environment mapping simplification is logically equivalent but should be tested. trailing space cleanup and reportUri extraction improve code quality.
- verify `server/index.ts` environment mapping produces consistent sentry environment names

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .changeset/new-owl-try.md | changeset file documenting the csp activation for release notes |
| server/index.ts | uncomments csp configuration, switches from enforcement to report-only mode, extracts reportUri variable, fixes trailing spaces, simplifies environment mapping |

</details>



<sub>Last reviewed commit: 9300107</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled Content Security Policy reporting in report-only mode to enhance security monitoring and tracking of potential policy violations for frontend assets without blocking legitimate requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->