### PR TITLE
🥅 app: refine known error classification granularity

### DIFF
--- a/.changeset/bright-foxes-glow.md
+++ b/.changeset/bright-foxes-glow.md
@@ -1,0 +1,5 @@
+---
+"@exactly/mobile": patch
+---
+
+🥅 refine known error classification granularity


### PR DESCRIPTION
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exactly/exa/pull/826" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined error classification system to better distinguish between different error severity levels, enhancing error reporting accuracy and user feedback precision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

refines error classification system by splitting the binary `known` flag into two distinct severity levels: `knownWarning` for authentication-related errors (passkey issues, biometric errors) and `knownInfo` for network-related errors. this allows more nuanced error reporting in sentry, where network errors are now tagged as "info" level instead of "warning", reducing noise in error monitoring.

- splits `known` boolean into `knownWarning` and `knownInfo` properties in error classification
- updates sentry `beforeSend` hook to apply info-level for `knownInfo` errors, warning-level for `knownWarning` errors
- classifies all network errors (connection lost, offline, request failed, tls failure, timeout) as info-level
- marks update check errors in `_layout.tsx` as info-level explicitly using `reportError(error, { level: "info" })`

<h3>Confidence Score: 5/5</h3>

- safe to merge - well-structured refactoring with clear intent
- the changes are a straightforward, logical refactoring that improves error classification granularity. the implementation correctly maintains backward compatibility by keeping the `known` property as a union of the two new properties. all call sites are properly updated to use the new properties.
- no files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .changeset/bright-foxes-glow.md | adds changeset entry for error classification refinement |
| src/utils/reportError.ts | splits `known` classification into `knownWarning` and `knownInfo`, separates network errors as info-level |
| src/app/_layout.tsx | applies new error classification in sentry `beforeSend` hook, marks update check errors as info-level |

</details>



<sub>Last reviewed commit: 820bee8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->