### PR TITLE
🥅 app: map web domains to sentry environments

### DIFF
--- a/.changeset/soft-emu-run.md
+++ b/.changeset/soft-emu-run.md
@@ -1,0 +1,5 @@
+---
+"@exactly/mobile": patch
+---
+
+🥅 map web domains to sentry environments

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -103,7 +103,16 @@ init({
   dsn:
     process.env.EXPO_PUBLIC_SENTRY_DSN ??
     "https://ac8875331e4cecd67dd0a7519a36dfeb@o1351734.ingest.us.sentry.io/4506186349674496",
-  environment: e2e ? "e2e" : __DEV__ ? "development" : (channel ?? "production"),
+  environment: e2e
+    ? "e2e"
+    : (channel ??
+      (Platform.OS === "web"
+        ? ({ "web.exactly.app": "production" }[domain] ??
+          /^(?<subdomain>.+)\.exactly\.app$/.exec(domain)?.groups?.subdomain ??
+          "development")
+        : __DEV__
+          ? "development"
+          : "production")),
   tracesSampleRate: 1,
   attachStacktrace: true,
   attachViewHierarchy: true,


### PR DESCRIPTION
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exactly/exa/pull/827" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment detection for error reporting: refined web domain-based mapping and clearer native development/production distinction.

* **Chores**
  * Added a patch changeset to publish the package with the updated environment mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

improved sentry environment detection for web platform by mapping specific domains to environments. production environment is now assigned to `web.exactly.app`, subdomain-based environments are detected via regex extraction (e.g., `sandbox.exactly.app` → `sandbox`), and development is the default fallback. native platforms continue using the existing `channel` or `__DEV__`-based logic.

- maps `web.exactly.app` domain explicitly to production environment
- extracts subdomain from `*.exactly.app` domains as environment name
- falls back to development for unmapped web domains
- preserves existing native platform logic with proper operator precedence

<h3>Confidence Score: 5/5</h3>

- this pr is safe to merge with no identified issues
- the change is well-structured with proper operator precedence and parentheses, follows the project's code style, and enhances environment detection for better error tracking without breaking existing behavior
- no files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .changeset/soft-emu-run.md | adds changeset for environment mapping feature, follows proper format |
| src/app/_layout.tsx | maps web domains to sentry environments with proper fallback logic and correct operator precedence |

</details>



<sub>Last reviewed commit: 4494f62</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->