### PR TITLE
🐛 server: handle failed onboarding tasks in manteca

### DIFF
--- a/.changeset/fancy-ends-dance.md
+++ b/.changeset/fancy-ends-dance.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+🐛 handle failed onboarding tasks in manteca

--- a/server/api/ramp.ts
+++ b/server/api/ramp.ts
@@ -181,6 +181,7 @@ export default new Hono()
         case "manteca": {
           const mantecaUser = await manteca.getUser(account);
           if (!mantecaUser) return c.json({ code: ErrorCodes.NOT_STARTED }, 400);
+          if (mantecaUser.status !== "ACTIVE") return c.json({ code: ErrorCodes.NOT_APPROVED }, 400);
           try {
             const depositInfo: InferOutput<typeof RampResponse>["depositInfo"] = manteca.getDepositDetails(
               query.currency,

--- a/server/test/api/ramp.test.ts
+++ b/server/test/api/ramp.test.ts
@@ -200,6 +200,20 @@ describe("ramp api", () => {
         await expect(response.json()).resolves.toStrictEqual({ code: "not started" });
       });
 
+      it("returns 400 if manteca user is not active", async () => {
+        vi.spyOn(manteca, "getUser").mockResolvedValue({ ...mantecaUser, status: "ONBOARDING" });
+        const quoteSpy = vi.spyOn(manteca, "getQuote");
+
+        const response = await appClient.quote.$get(
+          { query: { provider: "manteca", currency: "ARS" } },
+          { headers: { "test-credential-id": "ramp-test" } },
+        );
+
+        expect(response.status).toBe(400);
+        await expect(response.json()).resolves.toStrictEqual({ code: "not approved" });
+        expect(quoteSpy).not.toHaveBeenCalled();
+      });
+
       it("returns quote and deposit info for manteca ARS", async () => {
         vi.spyOn(manteca, "getUser").mockResolvedValue(mantecaUser);
         vi.spyOn(manteca, "getQuote").mockResolvedValue({ buyRate: "1000", sellRate: "1010" });

--- a/server/test/utils/manteca.test.ts
+++ b/server/test/utils/manteca.test.ts
@@ -353,6 +353,22 @@ describe("manteca utils", () => {
       expect(result.status).toBe("NOT_AVAILABLE");
     });
 
+    it("returns ONBOARDING when user has failed required tasks", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+        mockFetchResponse({
+          ...mockOnboardingUser,
+          onboarding: {
+            EMAIL_VALIDATION: { required: true, status: "PENDING" },
+            IDENTITY_VALIDATION: { required: true, status: "FAILED" },
+          },
+        }),
+      );
+
+      const result = await manteca.getProvider(account, "AR");
+
+      expect(result).toStrictEqual({ onramp: { currencies: ["ARS", "USD"] }, status: "ONBOARDING" });
+    });
+
     it("returns NOT_STARTED when user has pending required tasks", async () => {
       vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
         mockFetchResponse({

--- a/server/utils/ramps/manteca.ts
+++ b/server/utils/ramps/manteca.ts
@@ -252,10 +252,23 @@ export async function getProvider(account: Address, countryCode?: string) {
   if (mantecaUser.status === "INACTIVE") {
     return { onramp: { currencies: [] }, status: "NOT_AVAILABLE" as const };
   }
-  const hasPendingTasks = Object.values(mantecaUser.onboarding).some(
-    (task) => task.required && task.status === "PENDING",
-  );
-  if (hasPendingTasks) {
+
+  if (Object.values(mantecaUser.onboarding).some((task) => task.required && task.status === "FAILED")) {
+    // TODO handle failed required tasks
+    withScope((scope) => {
+      scope.addEventProcessor((event) => {
+        if (event.exception?.values?.[0]) event.exception.values[0].type = "has failed tasks";
+        return event;
+      });
+      captureException(new Error("has failed tasks"), {
+        level: "warning",
+        fingerprint: ["{{ default }}", "has failed tasks"],
+      });
+    });
+    return { onramp: { currencies }, status: "ONBOARDING" as const };
+  }
+
+  if (Object.values(mantecaUser.onboarding).some((task) => task.required && task.status === "PENDING")) {
     withScope((scope) => {
       scope.addEventProcessor((event) => {
         if (event.exception?.values?.[0]) event.exception.values[0].type = "has pending tasks";
@@ -264,7 +277,6 @@ export async function getProvider(account: Address, countryCode?: string) {
       captureException(new Error("has pending tasks"), {
         level: "warning",
         fingerprint: ["{{ default }}", "has pending tasks"],
-        contexts: { mantecaUser },
       });
     });
     return { onramp: { currencies }, status: "NOT_STARTED" as const };
@@ -468,7 +480,7 @@ export const BalancesResponse = object({
   updatedAt: string(),
 });
 
-const onboardingTaskStatus = ["PENDING", "COMPLETED", "IN_PROGRESS"] as const;
+const onboardingTaskStatus = ["COMPLETED", "FAILED", "IN_PROGRESS", "PENDING"] as const;
 const OnboardingTaskInfo = optional(
   object({
     required: boolean(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated onboarding determination so required onboarding tasks in a `FAILED` state are treated as requiring onboarding, directing users to complete verification and logging a warning.
* **Tests**
  * Added coverage for the `FAILED` required-task scenario to ensure the provider reports the correct onboarding status.
* **Chores**
  * Added a patch-release changeset entry documenting the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->