### PR TITLE
🥅 server: bind account address to sentry instrumentation scopes

### DIFF
--- a/.changeset/weak-dove-play.md
+++ b/.changeset/weak-dove-play.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+🥅 bind account address to sentry instrumentation scopes

--- a/server/hooks/panda.ts
+++ b/server/hooks/panda.ts
@@ -465,10 +465,10 @@ export default new Hono().post(
             }),
             getUser(payload.body.spend.userId),
           ]);
-          if (!user.isActive) throw new Error("user is not active");
           if (!card) throw new Error("card not found");
           const account = v.parse(Address, card.credential.account);
           setUser({ id: account });
+          if (!user.isActive) throw new Error("user is not active");
 
           const tx = await database.query.transactions.findFirst({
             where: and(eq(transactions.id, payload.body.id), eq(transactions.cardId, payload.body.spend.cardId)),

--- a/server/test/hooks/activity.test.ts
+++ b/server/test/hooks/activity.test.ts
@@ -4,7 +4,7 @@ import "../mocks/keeper";
 import "../mocks/onesignal";
 import "../mocks/sentry";
 
-import { captureException } from "@sentry/node";
+import { captureException, setUser } from "@sentry/node";
 import { testClient } from "hono/testing";
 import {
   BaseError,
@@ -85,6 +85,7 @@ describe("address activity", () => {
     expect(
       vi.mocked(captureException).mock.calls.filter(([error, hint]) => isNoBalance(error, hint, "error")),
     ).toHaveLength(0);
+    expect(setUser).toHaveBeenCalledWith({ id: account });
     expect(response.status).toBe(200);
   });
 
@@ -113,6 +114,7 @@ describe("address activity", () => {
       vi.mocked(captureException).mock.calls.filter(([error, hint]) => isNoBalance(error, hint, "warning")),
     ).toHaveLength(0);
 
+    expect(setUser).toHaveBeenCalledWith({ id: account });
     expect(response.status).toBe(200);
   });
 
@@ -145,6 +147,7 @@ describe("address activity", () => {
       vi.mocked(captureException).mock.calls.filter(([error, hint]) => isNoBalance(error, hint, "warning")),
     ).toHaveLength(0);
 
+    expect(setUser).toHaveBeenCalledWith({ id: account });
     expect(response.status).toBe(200);
   });
 
@@ -184,6 +187,7 @@ describe("address activity", () => {
     expect(
       vi.mocked(captureException).mock.calls.filter(([error, hint]) => isNoBalance(error, hint, "warning")),
     ).toHaveLength(0);
+    expect(setUser).toHaveBeenCalledWith({ id: account });
     expect(response.status).toBe(200);
   });
 
@@ -218,6 +222,7 @@ describe("address activity", () => {
     expect(
       vi.mocked(captureException).mock.calls.filter(([error, hint]) => isNoBalance(error, hint, "warning")),
     ).toHaveLength(0);
+    expect(setUser).toHaveBeenCalledWith({ id: account });
     expect(response.status).toBe(200);
   });
 
@@ -250,6 +255,7 @@ describe("address activity", () => {
     expect(
       vi.mocked(captureException).mock.calls.filter(([error, hint]) => isNoBalance(error, hint, "warning")),
     ).toHaveLength(0);
+    expect(setUser).toHaveBeenCalledWith({ id: account });
     expect(response.status).toBe(200);
   });
 
@@ -288,6 +294,7 @@ describe("address activity", () => {
     expect(
       vi.mocked(captureException).mock.calls.filter(([error, hint]) => isNoBalance(error, hint, "warning")),
     ).toHaveLength(0);
+    expect(setUser).toHaveBeenCalledWith({ id: account });
     expect(response.status).toBe(200);
   });
 
@@ -324,6 +331,7 @@ describe("address activity", () => {
     expect(
       vi.mocked(captureException).mock.calls.filter(([error, hint]) => isNoBalance(error, hint, "warning")),
     ).toHaveLength(0);
+    expect(setUser).toHaveBeenCalledWith({ id: account });
     expect(response.status).toBe(200);
   });
 
@@ -355,6 +363,7 @@ describe("address activity", () => {
     expect(
       vi.mocked(captureException).mock.calls.filter(([error, hint]) => isNoBalance(error, hint, "warning")),
     ).toHaveLength(0);
+    expect(setUser).toHaveBeenCalledWith({ id: account });
     expect(response.status).toBe(200);
   });
 
@@ -386,6 +395,7 @@ describe("address activity", () => {
     expect(
       vi.mocked(captureException).mock.calls.filter(([error, hint]) => isNoBalance(error, hint, "warning")),
     ).toHaveLength(0);
+    expect(setUser).toHaveBeenCalledWith({ id: account });
     expect(response.status).toBe(200);
   });
 
@@ -415,6 +425,7 @@ describe("address activity", () => {
     expect(
       vi.mocked(captureException).mock.calls.filter(([error, hint]) => isNoBalance(error, hint, "warning")),
     ).toHaveLength(0);
+    expect(setUser).toHaveBeenCalledWith({ id: account });
     expect(response.status).toBe(200);
   });
 
@@ -442,6 +453,7 @@ describe("address activity", () => {
     expect(
       vi.mocked(captureException).mock.calls.filter(([error, hint]) => isNoBalance(error, hint, "warning")),
     ).toHaveLength(0);
+    expect(setUser).toHaveBeenCalledWith({ id: account });
     expect(response.status).toBe(200);
   });
 
@@ -465,6 +477,7 @@ describe("address activity", () => {
 
     expect(market.floatingDepositAssets).toBe(deposit);
     expect(market.isCollateral).toBe(true);
+    expect(setUser).toHaveBeenCalledWith({ id: account });
     expect(response.status).toBe(200);
   });
 
@@ -602,6 +615,7 @@ describe("address activity", () => {
 
     expect(market.floatingDepositAssets).toBe(eth + weth);
     expect(market.isCollateral).toBe(true);
+    expect(setUser).toHaveBeenCalledWith({ id: account });
     expect(response.status).toBe(200);
   });
 
@@ -743,6 +757,7 @@ describe("address activity", () => {
       ),
     ]);
 
+    expect(setUser).not.toHaveBeenCalled();
     expect(response.status).toBe(200);
   });
 
@@ -764,6 +779,7 @@ describe("address activity", () => {
     const deployed = !!(await publicClient.getCode({ address: account }));
 
     expect(deployed).toBe(true);
+    expect(setUser).toHaveBeenCalledWith({ id: account });
     expect(response.status).toBe(200);
   });
 
@@ -788,6 +804,7 @@ describe("address activity", () => {
     });
 
     expect(sendPushNotification).not.toHaveBeenCalled();
+    expect(setUser).toHaveBeenCalledWith({ id: account });
     expect(response.status).toBe(200);
   });
 });


### PR DESCRIPTION
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exactly/exa/pull/832" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Monitoring now attaches account user context to per-account operations, ensuring errors and statuses are reported with the correct account identity and consolidated per-operation status.

* **Bug Fixes**
  * Improved error reporting paths so captured exceptions include account context and overall activity status reflects aggregated failures.

* **Tests**
  * Added and updated tests validating account user context is set across success, no-balance, and error scenarios.

* **Chores**
  * Added a patch release note documenting the instrumentation scope change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

improved sentry error tracking by consistently binding account addresses to instrumentation scopes across all per-account server operations. previously, account context was inconsistently attached via tags; now user identity is set uniformly via `setUser`, enabling account-scoped diagnostics in sentry.

## key changes
- `server/utils/keeper.ts`: automatically extracts and validates account from span attributes, sets user context for all keeper operations
- `server/hooks/activity.ts`: sets user context at request level (single account) and per-account operation level, adds user binding in error capture scopes, removes redundant `exa.account` tag
- `server/hooks/block.ts`: wraps async operations with user context binding for proposals and withdrawals, ensures account context in error handlers
- `server/hooks/panda.ts`: reorders validation to set user context before throwing errors
- comprehensive test coverage verifying user context is set correctly across success, error, and edge-case paths

<h3>Confidence Score: 5/5</h3>

- safe to merge - this is a monitoring instrumentation improvement with no functional changes to business logic
- changes are limited to adding sentry user context bindings and removing redundant tags. all modifications preserve existing error handling and business logic. comprehensive test coverage verifies user context is set correctly across all code paths (success, error, no-balance scenarios). the refactoring in `activity.ts` simplifies status logic without changing behavior
- no files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/hooks/activity.ts | binds account user context to sentry scopes for activity operations, removes redundant `exa.account` tag, refactors status logic |
| server/hooks/block.ts | binds account user context to sentry scopes for proposal and withdraw operations, removes redundant `exa.account` tag |
| server/hooks/panda.ts | reorders checks to bind account user context before throwing errors |
| server/utils/keeper.ts | extracts and validates account from span attributes, automatically binds user context for all keeper operations |

</details>



<sub>Last reviewed commit: 6d5d477</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->