### PR TITLE
✨ app: provision alchemy rpc urls across lifi chains

### DIFF
--- a/.changeset/bright-llamas-provision.md
+++ b/.changeset/bright-llamas-provision.md
@@ -1,0 +1,5 @@
+---
+"@exactly/mobile": patch
+---
+
+✨ provision alchemy rpc urls across lifi chains

--- a/.changeset/five-schools-go.md
+++ b/.changeset/five-schools-go.md
@@ -1,0 +1,5 @@
+---
+"@exactly/mobile": patch
+---
+
+🥅 surface lifi token errors

--- a/.changeset/metal-suits-strive.md
+++ b/.changeset/metal-suits-strive.md
@@ -1,0 +1,5 @@
+---
+"@exactly/mobile": patch
+---
+
+🐛 scope bridge destinations to current chain

--- a/.changeset/tame-gifts-float.md
+++ b/.changeset/tame-gifts-float.md
@@ -1,0 +1,5 @@
+---
+"@exactly/mobile": patch
+---
+
+🐛 cache lifi tokens by chain in bridge sources

--- a/.changeset/true-flies-battle.md
+++ b/.changeset/true-flies-battle.md
@@ -1,0 +1,5 @@
+---
+"@exactly/mobile": patch
+---
+
+🐛 refresh lifi balances after bridge

--- a/src/components/add-funds/Bridge.tsx
+++ b/src/components/add-funds/Bridge.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Pressable } from "react-native";
+import { Pressable, RefreshControl } from "react-native";
 
 import { useLocalSearchParams, useRouter } from "expo-router";
 
@@ -31,6 +31,7 @@ import {
   balancesOptions,
   bridgeSourcesOptions,
   getRouteFrom,
+  lifiTokensOptions,
   tokenAmountsToBalances,
   tokenCorrelation,
   type RouteFrom,
@@ -99,12 +100,24 @@ export default function Bridge() {
   const { mutateAsync: transfer } = useWriteContract({ config: senderConfig });
   const { protocolSymbols, protocolAssets, externalAssets } = usePortfolio();
 
-  const { data: bridge, isPending: isSourcesPending } = useQuery({
+  const {
+    data: bridge,
+    isPending: isSourcesPending,
+    refetch: refetchSources,
+  } = useQuery({
     ...bridgeSourcesOptions(senderAddress, protocolSymbols),
     refetchInterval: 60_000,
     refetchIntervalInBackground: true,
   });
-  const { data: balances } = useQuery(balancesOptions(senderAddress));
+  const { data: balances, refetch: refetchBalances } = useQuery(balancesOptions(senderAddress));
+  const { mutate: refresh, isPending: refreshing } = useMutation({
+    mutationFn: async () => {
+      if (!senderAddress) return;
+      queryClient.removeQueries({ queryKey: lifiTokensOptions.queryKey });
+      await Promise.all([refetchSources(), refetchBalances()]);
+    },
+    onError: (error) => reportError(error),
+  });
   const sameChainBalances = balances?.[chain.id];
 
   const chains = bridge?.chains;
@@ -166,7 +179,11 @@ export default function Bridge() {
   const isTransfer = isSameChain && !isExaSender;
   const isNativeSource = source?.address === zeroAddress;
 
-  const destinationTokens = useMemo(() => bridge?.destinationTokens ?? [], [bridge?.destinationTokens]);
+  const destinationTokens = useMemo(
+    () =>
+      bridge?.tokensByChain[chain.id]?.filter((token) => token.chainId === (chain.id as typeof token.chainId)) ?? [],
+    [bridge?.tokensByChain],
+  );
 
   const effectiveDestinationAddress = useMemo(() => {
     if (!sourceTokenAddress) return;
@@ -673,7 +690,11 @@ export default function Bridge() {
             }}
           />
         </View>
-        <ScrollView showsVerticalScrollIndicator={false} flex={1}>
+        <ScrollView
+          showsVerticalScrollIndicator={false}
+          flex={1}
+          refreshControl={<RefreshControl refreshing={refreshing} onRefresh={refresh} />}
+        >
           <View padded>
             <YStack gap="$s5">
               {isLoadingAssets && (
@@ -728,6 +749,20 @@ export default function Bridge() {
                     setSourceAmount(maxAmount);
                   }}
                 />
+              )}
+              {!isTransfer && !isSourcesPending && assetGroups.length > 0 && destinationTokens.length === 0 && (
+                <View
+                  borderWidth={1}
+                  borderColor="$borderWarningStrong"
+                  backgroundColor="$interactiveBaseWarningSoftDefault"
+                  borderRadius="$r3"
+                  padding="$s4"
+                  gap="$s3"
+                >
+                  <Text emphasized callout color="$interactiveOnBaseWarningSoft">
+                    {t("Something went wrong. Please try again.")}
+                  </Text>
+                </View>
               )}
               {insufficientBalance && (
                 <Text caption2 color="$interactiveOnBaseWarningSoft">

--- a/src/components/add-funds/Bridge.tsx
+++ b/src/components/add-funds/Bridge.tsx
@@ -166,7 +166,7 @@ export default function Bridge() {
   const isTransfer = isSameChain && !isExaSender;
   const isNativeSource = source?.address === zeroAddress;
 
-  const destinationTokens = useMemo(() => bridge?.tokensByChain[chain.id] ?? [], [bridge?.tokensByChain]);
+  const destinationTokens = useMemo(() => bridge?.destinationTokens ?? [], [bridge?.destinationTokens]);
 
   const effectiveDestinationAddress = useMemo(() => {
     if (!sourceTokenAddress) return;

--- a/src/components/add-funds/Bridge.tsx
+++ b/src/components/add-funds/Bridge.tsx
@@ -429,7 +429,7 @@ export default function Bridge() {
         if (!isExaSender) await switchChain(senderConfig, { chainId: chain.id }).catch(reportError);
       }
     },
-    onSuccess: async () => {
+    onSuccess: () => {
       toast.show(
         bridgePreview?.operation === "swap" ? t("Swap transaction submitted") : t("Bridge transaction submitted"),
         {
@@ -438,10 +438,22 @@ export default function Bridge() {
           burntOptions: { haptic: "success", preset: "done" },
         },
       );
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ["bridge", "sources"] }),
-        queryClient.invalidateQueries({ queryKey: ["lifi", "balances"] }),
-      ]);
+      const accounts = senderAddress ? [senderAddress] : [];
+      if (account && account.toLowerCase() !== senderAddress?.toLowerCase()) accounts.push(account);
+      const nonce = Date.now();
+      Promise.all(
+        accounts.map((item) =>
+          queryClient
+            .fetchQuery({ ...balancesOptions(item, nonce), staleTime: 0 })
+            .then((fresh) => {
+              queryClient.setQueryData(balancesOptions(item).queryKey, fresh);
+              queryClient.removeQueries({ queryKey: balancesOptions(item, nonce).queryKey });
+            })
+            .catch(reportError),
+        ),
+      )
+        .then(() => queryClient.invalidateQueries({ queryKey: ["bridge", "sources"] }))
+        .catch(reportError);
     },
     onError(error) {
       if (reportError(error).authKnown) {

--- a/src/components/shared/AssetLogo.tsx
+++ b/src/components/shared/AssetLogo.tsx
@@ -50,7 +50,7 @@ export default function AssetLogo({
     defaultUri ??
     (symbol
       ? getTokenLogoURI(
-          tokens.filter((token) => (token.chainId as number) === chain.id),
+          tokens.filter((token) => token.chainId === (chain.id as typeof token.chainId)),
           symbol,
         )
       : undefined);

--- a/src/utils/lifi.ts
+++ b/src/utils/lifi.ts
@@ -51,19 +51,14 @@ export const lifiTokensOptions = queryOptions({
   enabled: !chain.testnet && chain.id !== anvil.id,
   queryFn: async () => {
     if (chain.testnet || chain.id === anvil.id) return [];
-    try {
-      ensureConfig();
-      const { tokens } = await getTokens({ chainTypes: [ChainType.EVM] });
-      const allTokens = Object.values(tokens).flat();
-      if (chain.id !== infra.optimism.id) return allTokens;
-      const exa = await getToken(chain.id, "0x1e925De1c68ef83bD98eE3E130eF14a50309C01B").catch((error: unknown) => {
-        reportError(error);
-      });
-      return exa ? [exa, ...allTokens.filter((t) => t.address.toLowerCase() !== exa.address.toLowerCase())] : allTokens;
-    } catch (error) {
+    ensureConfig();
+    const { tokens } = await getTokens({ chainTypes: [ChainType.EVM] });
+    const allTokens = Object.values(tokens).flat();
+    if (chain.id !== infra.optimism.id) return allTokens;
+    const exa = await getToken(chain.id, "0x1e925De1c68ef83bD98eE3E130eF14a50309C01B").catch((error: unknown) => {
       reportError(error);
-      return [] as Token[];
-    }
+    });
+    return exa ? [exa, ...allTokens.filter((t) => t.address.toLowerCase() !== exa.address.toLowerCase())] : allTokens;
   },
 });
 

--- a/src/utils/lifi.ts
+++ b/src/utils/lifi.ts
@@ -48,12 +48,16 @@ export const lifiTokensOptions = queryOptions({
   queryKey: ["lifi", "tokens"],
   staleTime: Infinity,
   gcTime: Infinity,
+  retry: 3,
   enabled: !chain.testnet && chain.id !== anvil.id,
   queryFn: async () => {
     if (chain.testnet || chain.id === anvil.id) return [];
     ensureConfig();
     const { tokens } = await getTokens({ chainTypes: [ChainType.EVM] });
     const allTokens = Object.values(tokens).flat();
+    if (!allTokens.some((token) => token.chainId === (chain.id as typeof token.chainId))) {
+      throw new Error("missing destination tokens");
+    }
     if (chain.id !== infra.optimism.id) return allTokens;
     const exa = await getToken(chain.id, "0x1e925De1c68ef83bD98eE3E130eF14a50309C01B").catch((error: unknown) => {
       reportError(error);
@@ -382,7 +386,7 @@ export type BridgeSources = {
   chains: ExtendedChain[];
   defaultChainId?: number;
   defaultTokenAddress?: string;
-  destinationTokens: Token[];
+  tokensByChain: Record<number, Token[]>;
   usdByChain: Record<number, number>;
   usdByToken: Record<string, number>;
 };
@@ -390,15 +394,21 @@ export type BridgeSources = {
 export async function getBridgeSources(account?: Address): Promise<BridgeSources> {
   ensureConfig();
   if (!account) throw new Error("account is required");
+  const cachedTokens = queryClient.getQueryData<Token[]>(lifiTokensOptions.queryKey);
   const [supportedChains, allTokens, allBalances] = await Promise.all([
     queryClient.getQueryData<ExtendedChain[]>(lifiChainsOptions.queryKey) ?? queryClient.fetchQuery(lifiChainsOptions),
-    queryClient.getQueryData<Token[]>(lifiTokensOptions.queryKey) ?? queryClient.fetchQuery(lifiTokensOptions),
+    cachedTokens?.some((token) => token.chainId === (chain.id as typeof token.chainId))
+      ? cachedTokens
+      : queryClient.fetchQuery(lifiTokensOptions).catch((error: unknown) => {
+          reportError(error);
+          return [] as Token[];
+        }),
     queryClient.fetchQuery(balancesOptions(account)),
   ]);
 
   const usdByChain: Record<number, number> = {};
   const usdByToken: Record<string, number> = {};
-  const destinationTokens = allTokens.filter((token) => (token.chainId as number) === chain.id);
+  const destinationTokens = allTokens.filter((token) => token.chainId === (chain.id as typeof token.chainId));
   const balancesByChain: Record<number, TokenBalance[]> = {};
 
   for (const [chainId, tokenAmounts] of Object.entries(allBalances)) {
@@ -438,7 +448,7 @@ export async function getBridgeSources(account?: Address): Promise<BridgeSources
 
   return {
     chains,
-    destinationTokens,
+    tokensByChain: { [chain.id]: destinationTokens },
     usdByChain,
     usdByToken,
     balancesByChain,

--- a/src/utils/lifi.ts
+++ b/src/utils/lifi.ts
@@ -1,4 +1,4 @@
-import { optimism } from "@account-kit/infra";
+import * as infra from "@account-kit/infra";
 import {
   ChainType,
   config,
@@ -53,9 +53,9 @@ export const lifiTokensOptions = queryOptions({
     if (chain.testnet || chain.id === anvil.id) return [];
     try {
       ensureConfig();
-      const { tokens } = await getTokens({ chains: [chain.id] });
-      const allTokens = tokens[chain.id] ?? [];
-      if (chain.id !== optimism.id) return allTokens;
+      const { tokens } = await getTokens({ chainTypes: [ChainType.EVM] });
+      const allTokens = Object.values(tokens).flat();
+      if (chain.id !== infra.optimism.id) return allTokens;
       const exa = await getToken(chain.id, "0x1e925De1c68ef83bD98eE3E130eF14a50309C01B").catch((error: unknown) => {
         reportError(error);
       });
@@ -81,7 +81,7 @@ export function balancesOptions(account: Address | undefined) {
           reportError(error);
           return {} as Record<number, TokenAmount[]>;
         }),
-        chain.id === optimism.id
+        chain.id === infra.optimism.id
           ? getToken(chain.id, "0x1e925De1c68ef83bD98eE3E130eF14a50309C01B")
               .then((token) => getTokenBalancesByChain(account, { [chain.id]: [token] }))
               .then((result) => result[chain.id]?.[0])
@@ -116,13 +116,28 @@ function ensureConfig() {
   createLifiConfig({
     integrator: "exa_app",
     apiKey: "4bdb54aa-4f28-4c61-992a-a2fdc87b0a0b.251e33ad-ef5e-40cb-9b0f-52d634b99e8f",
+    preloadChains: false,
     providers: [EVM({ getWalletClient: () => Promise.resolve(publicClient) })],
-    rpcUrls: {
-      [optimism.id]: [`${optimism.rpcUrls.alchemy?.http[0]}/${alchemyAPIKey}`],
-      [chain.id]: [publicClient.transport.alchemyRpcUrl],
-    },
+    rpcUrls: Object.values(infra).reduce<Record<number, string[]>>((result, item) => {
+      if (typeof item !== "object" || !("id" in item) || !("rpcUrls" in item)) return result;
+      const { id, rpcUrls } = item as { id: number; rpcUrls: { alchemy?: { http?: readonly string[] } } };
+      const url = rpcUrls.alchemy?.http?.[0];
+      if (!url) return result;
+      result[id] = [`${url}/${alchemyAPIKey}`];
+      return result;
+    }, {}),
   });
+  config.loading = getChains({ chainTypes: [ChainType.EVM] })
+    .then((availableChains) => {
+      config.setChains(availableChains);
+      queryClient.setQueryData(lifiChainsOptions.queryKey, availableChains);
+    })
+    .catch((error: unknown) => {
+      configured = false;
+      reportError(error);
+    });
   configured = true;
+  queryClient.prefetchQuery(lifiTokensOptions).catch(reportError);
 }
 
 export async function getRoute(

--- a/src/utils/lifi.ts
+++ b/src/utils/lifi.ts
@@ -387,7 +387,7 @@ export type BridgeSources = {
   chains: ExtendedChain[];
   defaultChainId?: number;
   defaultTokenAddress?: string;
-  tokensByChain: Record<number, Token[]>;
+  destinationTokens: Token[];
   usdByChain: Record<number, number>;
   usdByToken: Record<string, number>;
 };
@@ -395,7 +395,7 @@ export type BridgeSources = {
 export async function getBridgeSources(account?: Address): Promise<BridgeSources> {
   ensureConfig();
   if (!account) throw new Error("account is required");
-  const [supportedChains, destinationTokens, allBalances] = await Promise.all([
+  const [supportedChains, allTokens, allBalances] = await Promise.all([
     queryClient.getQueryData<ExtendedChain[]>(lifiChainsOptions.queryKey) ?? queryClient.fetchQuery(lifiChainsOptions),
     queryClient.getQueryData<Token[]>(lifiTokensOptions.queryKey) ?? queryClient.fetchQuery(lifiTokensOptions),
     queryClient.fetchQuery(balancesOptions(account)),
@@ -403,7 +403,7 @@ export async function getBridgeSources(account?: Address): Promise<BridgeSources
 
   const usdByChain: Record<number, number> = {};
   const usdByToken: Record<string, number> = {};
-  const tokensByChain: Record<number, Token[]> = { [chain.id]: destinationTokens };
+  const destinationTokens = allTokens.filter((token) => (token.chainId as number) === chain.id);
   const balancesByChain: Record<number, TokenBalance[]> = {};
 
   for (const [chainId, tokenAmounts] of Object.entries(allBalances)) {
@@ -443,7 +443,7 @@ export async function getBridgeSources(account?: Address): Promise<BridgeSources
 
   return {
     chains,
-    tokensByChain,
+    destinationTokens,
     usdByChain,
     usdByToken,
     balancesByChain,

--- a/src/utils/lifi.ts
+++ b/src/utils/lifi.ts
@@ -66,9 +66,9 @@ export const lifiTokensOptions = queryOptions({
   },
 });
 
-export function balancesOptions(account: Address | undefined) {
+export function balancesOptions(account: Address | undefined, nonce?: number) {
   return queryOptions({
-    queryKey: ["lifi", "balances", account],
+    queryKey: nonce === undefined ? ["lifi", "balances", account] : ["lifi", "balances", account, nonce],
     staleTime: 30_000,
     gcTime: 60_000,
     enabled: !!account && !chain.testnet && chain.id !== anvil.id,
@@ -76,7 +76,7 @@ export function balancesOptions(account: Address | undefined) {
       if (!account) return {} as Record<number, TokenAmount[]>;
       ensureConfig();
       const [balances, exa] = await Promise.all([
-        getWalletBalances(account).catch((error: unknown) => {
+        getWalletBalances(account, nonce).catch((error: unknown) => {
           reportError(error);
           return {} as Record<number, TokenAmount[]>;
         }),
@@ -457,7 +457,7 @@ export async function getBridgeSources(account?: Address): Promise<BridgeSources
   };
 }
 
-async function getWalletBalances(account: Address) {
+async function getWalletBalances(account: Address, nonce?: number) {
   const balances: Record<number, TokenAmount[]> = {};
   const lifiConfig = config.get();
   let offset: string | undefined;
@@ -465,6 +465,7 @@ async function getWalletBalances(account: Address) {
     const url = new URL(`${lifiConfig.apiUrl}/wallets/${account}/balances`);
     url.searchParams.set("extended", "true");
     url.searchParams.set("limit", "1000");
+    if (nonce !== undefined) url.searchParams.set("_", String(nonce));
     if (offset) url.searchParams.set("offset", offset);
     const response = await fetch(url, {
       headers: {


### PR DESCRIPTION
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exactly/exa/pull/833" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

replaces hardcoded optimism rpc url with dynamic provisioning across all lifi-supported evm chains by iterating through `@account-kit/infra` exports. adds `preloadChains: false` and async chain loading via `config.loading` to defer chain configuration until after the initial lifi setup.

- improves multi-chain support by automatically provisioning alchemy rpc urls for all chains in the `@account-kit/infra` package
- changes from synchronous to asynchronous chain loading pattern with `config.loading` promise
- **critical issue**: race condition at line 122 where `configured = true` is set before `config.loading` completes, which may cause subsequent function calls to proceed before chains are fully loaded

<h3>Confidence Score: 2/5</h3>

- this pr has a critical race condition that could cause runtime issues in production
- the race condition at line 122 where `configured` is set to `true` before the async `config.loading` promise completes could cause functions like `getRoute`, `getAllTokens`, and others to execute before chains are fully configured via `config.setChains`. this may lead to unpredictable behavior when lifi operations are called quickly after initialization.
- src/utils/lifi.ts requires attention for the race condition in `ensureConfig` function

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/utils/lifi.ts | dynamically provisions alchemy rpc urls across all lifi-supported chains by iterating through `@account-kit/infra` exports and adds async chain loading with `preloadChains: false` |
| .changeset/bright-llamas-provision.md | adds patch changeset documenting the lifi chain provisioning feature |

</details>



<sub>Last reviewed commit: a3f82fa</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a patch changelog entry for provisioning Alchemy RPC URLs across LiFi chains.

* **Bug Fixes & Improvements**
  * More reliable provisioning of Alchemy RPC endpoints across supported chains.
  * Dynamic, runtime discovery and asynchronous configuration of chains to reduce manual updates and report failures without interrupting the app.
  * Token preloading now avoids adding chain-specific extras on unrelated networks (extra token only fetched on Optimism).
  * Bridge token mappings limited to tokens that actually belong to each chain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->