### PR TITLE
🚑 server: fix zero-amount transfer detection

### DIFF
--- a/.changeset/bright-falcon-leap.md
+++ b/.changeset/bright-falcon-leap.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+🚑 fix zero-amount transfer detection


### PR DESCRIPTION
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exactly/exa/pull/835" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection to exclude zero-amount or missing-value transfers from processing and notifications.

* **Improvements**
  * Activity payloads now consistently include raw amount information so deposits and balances reflect correct token/ETH units across events.

* **Tests**
  * Added comprehensive tests covering ETH/WETH and token transfers with missing, zero, or present raw amounts to validate behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

fixed detection of zero-amount or missing-value transfers by checking the `rawValue` field (raw token/eth amounts in wei) instead of relying solely on the optional parsed `value` field

- updated validation schema to include optional `rawValue: Hex` in `rawContract` for both eth and erc20 transfers
- changed filter logic in `server/hooks/activity.ts:96` to check if `rawContract.rawValue` exists and is greater than zero when present, falling back to `!!value` check
- the new logic handles edge cases: `rawValue` missing, `rawValue` as `"0x"`, `rawValue` as `"0x0"`, and missing `value` field
- updated test helper in `.maestro/src/server.ts` to always include `rawValue` by parsing the decimal value using `parseUnits` with proper decimals
- added comprehensive test coverage for all edge cases including eth/weth transfers without value field and tokens with zero `rawValue`

<h3>Confidence Score: 5/5</h3>

- safe to merge with high confidence
- the change correctly fixes a real bug in zero-amount detection, is well-tested with comprehensive coverage of edge cases, uses proper viem utilities (`hexToBigInt`, `parseUnits`), follows existing code patterns, and maintains backward compatibility by falling back to the `value` field when `rawValue` is missing
- no files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| server/hooks/activity.ts | improved transfer filtering to use `rawValue` field for accurate zero-amount detection instead of relying on optional parsed `value` |
| .maestro/src/server.ts | added `rawValue` field to test payloads using `parseUnits` to provide actual token amounts in wei units for accurate testing |
| server/test/hooks/activity.test.ts | added comprehensive test coverage for eth/token transfers with missing or zero `rawValue`, and updated existing test payload |

</details>



<sub>Last reviewed commit: f9b3b7b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->