### PR TITLE
🚑 app: hotfix show only manteca ramp

### DIFF
--- a/.changeset/salty-bears-fly.md
+++ b/.changeset/salty-bears-fly.md
@@ -1,0 +1,5 @@
+---
+"@exactly/mobile": patch
+---
+
+🚑 hotfix show only manteca ramp

--- a/src/components/add-funds/AddFunds.tsx
+++ b/src/components/add-funds/AddFunds.tsx
@@ -111,19 +111,21 @@ export default function AddFunds() {
               ) : (
                 providers && (
                   <YStack gap="$s4">
-                    {Object.entries(providers).flatMap(([providerKey, provider]) =>
-                      provider.onramp.currencies.flatMap((currency) =>
-                        typeof currency === "string"
-                          ? [
-                              <AddFiatButton
-                                key={`${providerKey}-${currency}`}
-                                currency={currency}
-                                status={provider.status}
-                              />,
-                            ]
-                          : [],
-                      ),
-                    )}
+                    {Object.entries(providers)
+                      .filter(([providerKey]) => providerKey === "manteca")
+                      .flatMap(([providerKey, provider]) =>
+                        provider.onramp.currencies.flatMap((currency) =>
+                          typeof currency === "string"
+                            ? [
+                                <AddFiatButton
+                                  key={`${providerKey}-${currency}`}
+                                  currency={currency}
+                                  status={provider.status}
+                                />,
+                              ]
+                            : [],
+                        ),
+                      )}
                   </YStack>
                 )
               )}


### PR DESCRIPTION
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exactly/exa/pull/863" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The "Add funds" UI now shows funding options only from the manteca provider. Currency choices have been narrowed accordingly, resulting in a simplified, more consistent add-funds experience for users.

* **Chores**
  * Prepared a patch release noting the hotfix for manteca ramp behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This hotfix narrows the fiat on-ramp options in `AddFunds.tsx` so that only the `"manteca"` provider is displayed, suppressing any other providers that the API may return. The changeset file is correctly added as a patch.

A `.filter(([providerKey]) => providerKey === "manteca")` is inserted into the existing `Object.entries(providers).flatMap(...)` chain — the approach is minimal and correct for a hotfix. No new logic errors are introduced.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — the change is minimal, surgical, and achieves the intended hotfix goal.
- The diff is a single-line filter added to an existing chain; it correctly limits fiat on-ramp buttons to the manteca provider without touching any other logic. No new issues are introduced by this change.
- No files require special attention.

<sub>Last reviewed commit: 24cc666</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->