### PR TITLE
🔧 server: update manteca usd deposit details

### DIFF
--- a/.changeset/legal-eggs-hunt.md
+++ b/.changeset/legal-eggs-hunt.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+🔧 update manteca usd deposit details

--- a/server/test/api/ramp.test.ts
+++ b/server/test/api/ramp.test.ts
@@ -164,7 +164,8 @@ describe("ramp api", () => {
           depositInfo: [
             {
               beneficiaryName: "Sixalime Sas", // cspell:ignore Sixalime
-              cbu: "4310009942700000065019",
+              cbu: "4310009942700000124934",
+              depositAlias: "exa.usd",
               displayName: "CBU",
               estimatedProcessingTime: "300",
               fee: "0.0",

--- a/server/test/utils/manteca.test.ts
+++ b/server/test/utils/manteca.test.ts
@@ -67,7 +67,8 @@ describe("manteca utils", () => {
 
       expect(details).toHaveLength(1);
       expect(details[0]).toMatchObject({
-        cbu: "4310009942700000065019",
+        cbu: "4310009942700000124934",
+        depositAlias: "exa.usd",
         network: "ARG_FIAT_TRANSFER",
         displayName: "CBU",
       });

--- a/server/utils/ramps/manteca.ts
+++ b/server/utils/ramps/manteca.ts
@@ -136,7 +136,8 @@ export function getDepositDetails(currency: (typeof MantecaCurrency)[number], ex
       return [
         {
           beneficiaryName: "Sixalime Sas", // cspell:ignore Sixalime
-          cbu: "4310009942700000065019",
+          cbu: "4310009942700000124934",
+          depositAlias: "exa.usd",
           displayName: "CBU",
           estimatedProcessingTime: "300",
           fee: "0.0",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Manteca USD deposit details for Argentina: updated the CBU value and added a deposit alias (exa.usd). Tests were updated to expect the new values to ensure deposit instructions display correctly.

* **Chores**
  * Added a patch-level changeset note recording the deposit detail update for tracking and release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exactly/exa/pull/866" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
