### PR TITLE
🦺 server: return ok for non-processed persona templates

### DIFF
--- a/.changeset/spotty-tigers-tease.md
+++ b/.changeset/spotty-tigers-tease.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+🦺 return ok for non-processed persona templates

--- a/server/hooks/persona.ts
+++ b/server/hooks/persona.ts
@@ -13,6 +13,7 @@ import {
   nullable,
   object,
   optional,
+  picklist,
   pipe,
   safeParse,
   string,
@@ -25,7 +26,15 @@ import { Address } from "@exactly/common/validation";
 import database, { credentials } from "../database/index";
 import { createUser } from "../utils/panda";
 import { addCapita, deriveAssociateId } from "../utils/pax";
-import { addDocument, headerValidator, MANTECA_TEMPLATE_WITH_ID_CLASS, PANDA_TEMPLATE } from "../utils/persona";
+import {
+  addDocument,
+  ADDRESS_TEMPLATE,
+  CRYPTOMATE_TEMPLATE,
+  headerValidator,
+  MANTECA_TEMPLATE_EXTRA_FIELDS,
+  MANTECA_TEMPLATE_WITH_ID_CLASS,
+  PANDA_TEMPLATE,
+} from "../utils/persona";
 import { customer } from "../utils/sardine";
 import validatorHook from "../utils/validatorHook";
 
@@ -175,6 +184,22 @@ export default new Hono().post(
               }),
               transform((payload) => ({ template: "manteca" as const, ...payload })),
             ),
+            pipe(
+              object({
+                data: object({
+                  id: string(),
+                  attributes: object({ status: string(), referenceId: string() }),
+                  relationships: object({
+                    inquiryTemplate: object({
+                      data: object({
+                        id: picklist([ADDRESS_TEMPLATE, CRYPTOMATE_TEMPLATE, MANTECA_TEMPLATE_EXTRA_FIELDS]),
+                      }),
+                    }),
+                  }),
+                }),
+              }),
+              transform((payload) => ({ template: "ignored" as const, ...payload })),
+            ),
           ]),
         }),
       }),
@@ -183,6 +208,8 @@ export default new Hono().post(
   ),
   async (c) => {
     const payload = c.req.valid("json").data.attributes.payload;
+
+    if (payload.template === "ignored") return c.json({ code: "ok" }, 200);
 
     if (payload.template === "manteca") {
       getActiveSpan()?.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_OP, "persona.inquiry.manteca");

--- a/server/test/hooks/persona.test.ts
+++ b/server/test/hooks/persona.test.ts
@@ -7,7 +7,7 @@ import { eq } from "drizzle-orm";
 import { testClient } from "hono/testing";
 import { hexToBytes, padHex, zeroHash } from "viem";
 import { privateKeyToAddress } from "viem/accounts";
-import { afterEach, beforeAll, describe, expect, inject, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, inject, it, vi } from "vitest";
 
 import deriveAddress from "@exactly/common/deriveAddress";
 
@@ -264,6 +264,7 @@ describe("with reference", () => {
           'data/attributes/fields/currentGovernmentId1 Invalid key: Expected "currentGovernmentId1" but received undefined',
           'data/attributes/fields/selectedIdClass1 Invalid key: Expected "selectedIdClass1" but received undefined',
           'data/relationships/inquiryTemplate/data/id Invalid type: Expected "itmpl_TjaqJdQYkht17v645zNFUfkaWNan" but received "itmpl_1igCJVqgf3xuzqKYD87HrSaDavU2"',
+          'data/relationships/inquiryTemplate/data/id Invalid type: Expected ("itmpl_FTHNSXqJjoMvUTBc85QECGHogrZx" | "itmpl_8uim4FvD5P3kFpKHX37CW817" | "itmpl_gjYZshv7bc1DK8DNL8YYTQ1muejo") but received "itmpl_1igCJVqgf3xuzqKYD87HrSaDavU2"',
         ],
       });
       expect(panda.createUser).not.toHaveBeenCalled();
@@ -312,6 +313,7 @@ describe("with reference", () => {
           'data/attributes/fields/currentGovernmentId1 Invalid key: Expected "currentGovernmentId1" but received undefined',
           'data/attributes/fields/selectedIdClass1 Invalid key: Expected "selectedIdClass1" but received undefined',
           'data/relationships/inquiryTemplate/data/id Invalid type: Expected "itmpl_TjaqJdQYkht17v645zNFUfkaWNan" but received "itmpl_1igCJVqgf3xuzqKYD87HrSaDavU2"',
+          'data/relationships/inquiryTemplate/data/id Invalid type: Expected ("itmpl_FTHNSXqJjoMvUTBc85QECGHogrZx" | "itmpl_8uim4FvD5P3kFpKHX37CW817" | "itmpl_gjYZshv7bc1DK8DNL8YYTQ1muejo") but received "itmpl_1igCJVqgf3xuzqKYD87HrSaDavU2"',
         ],
       });
       expect(panda.createUser).not.toHaveBeenCalled();
@@ -360,6 +362,7 @@ describe("with reference", () => {
           'data/attributes/fields/currentGovernmentId1 Invalid key: Expected "currentGovernmentId1" but received undefined',
           'data/attributes/fields/selectedIdClass1 Invalid key: Expected "selectedIdClass1" but received undefined',
           'data/relationships/inquiryTemplate/data/id Invalid type: Expected "itmpl_TjaqJdQYkht17v645zNFUfkaWNan" but received "itmpl_1igCJVqgf3xuzqKYD87HrSaDavU2"',
+          'data/relationships/inquiryTemplate/data/id Invalid type: Expected ("itmpl_FTHNSXqJjoMvUTBc85QECGHogrZx" | "itmpl_8uim4FvD5P3kFpKHX37CW817" | "itmpl_gjYZshv7bc1DK8DNL8YYTQ1muejo") but received "itmpl_1igCJVqgf3xuzqKYD87HrSaDavU2"',
         ],
       });
       expect(panda.createUser).not.toHaveBeenCalled();
@@ -464,6 +467,64 @@ describe("manteca template", () => {
     expect(panda.createUser).not.toHaveBeenCalled();
   });
 });
+
+describe("ignored template", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("returns ok for address template", async () => {
+    const response = await appClient.index.$post({
+      header: { "persona-signature": "t=1,v1=sha256" },
+      json: ignoredPayload("itmpl_FTHNSXqJjoMvUTBc85QECGHogrZx"),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ code: "ok" });
+    expect(panda.createUser).not.toHaveBeenCalled();
+    expect(persona.addDocument).not.toHaveBeenCalled();
+  });
+
+  it("returns ok for cryptomate template", async () => {
+    const response = await appClient.index.$post({
+      header: { "persona-signature": "t=1,v1=sha256" },
+      json: ignoredPayload("itmpl_8uim4FvD5P3kFpKHX37CW817"),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ code: "ok" });
+    expect(panda.createUser).not.toHaveBeenCalled();
+    expect(persona.addDocument).not.toHaveBeenCalled();
+  });
+
+  it("returns ok for manteca extra fields template", async () => {
+    const response = await appClient.index.$post({
+      header: { "persona-signature": "t=1,v1=sha256" },
+      json: ignoredPayload("itmpl_gjYZshv7bc1DK8DNL8YYTQ1muejo"),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ code: "ok" });
+    expect(panda.createUser).not.toHaveBeenCalled();
+    expect(persona.addDocument).not.toHaveBeenCalled();
+  });
+});
+
+function ignoredPayload<T extends string>(templateId: T) {
+  return {
+    data: {
+      attributes: {
+        payload: {
+          data: {
+            id: "inq_ignored_123",
+            attributes: { status: "approved", referenceId: "ignored-ref" },
+            relationships: { inquiryTemplate: { data: { id: templateId } } },
+          },
+        },
+      },
+    },
+  } as const;
+}
 
 const validPayload = {
   data: {


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exactly/exa/pull/891" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved persona template processing to correctly identify non-processed templates and return a successful response immediately, bypassing unnecessary processing operations.

* **Tests**
  * Expanded test suite to verify correct handling of non-processed persona templates, ensuring no unnecessary user or document creation occurs for skipped template types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->