### PR TITLE
♿ app: compose limits as text for accessibility

### DIFF
--- a/src/components/home/CardStatus.tsx
+++ b/src/components/home/CardStatus.tsx
@@ -253,7 +253,16 @@ function LimitPaginator({
     t,
     i18n: { language },
   } = useTranslation();
+  const { data: hidden } = useQuery<boolean>({ queryKey: ["settings", "sensitive"] });
   const [width, setWidth] = useState(0);
+  const spending = (Number(spendingLimit) / 1e6).toLocaleString(language, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+  const credit = (Number(creditLimit) / 1e6).toLocaleString(language, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
   return (
     <View
       height={48}
@@ -273,20 +282,14 @@ function LimitPaginator({
                 <Info size={16} color="$interactiveBaseBrandDefault" />
               </Pressable>
             </XStack>
-            <XStack
-              alignItems="center"
-              aria-label={`$${(Number(spendingLimit) / 1e6).toLocaleString(language, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`}
-            >
-              <Text aria-hidden title3 secondary>
+            <Text title3 aria-label={hidden ? "***" : `$${spending}`}>
+              <Text aria-hidden secondary>
                 $
               </Text>
-              <Text sensitive aria-hidden title3 emphasized>
-                {(Number(spendingLimit) / 1e6).toLocaleString(language, {
-                  minimumFractionDigits: 2,
-                  maximumFractionDigits: 2,
-                })}
+              <Text aria-hidden sensitive emphasized>
+                {spending}
               </Text>
-            </XStack>
+            </Text>
           </XStack>
           <XStack width={width} height={48} alignItems="center" gap="$s3" paddingHorizontal="$s4">
             <CreditCard size={20} color="$uiNeutralSecondary" />
@@ -305,20 +308,14 @@ function LimitPaginator({
                 })}
               </Text>
             </YStack>
-            <XStack
-              alignItems="center"
-              aria-label={`$${(Number(creditLimit) / 1e6).toLocaleString(language, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`}
-            >
-              <Text aria-hidden title3 secondary>
+            <Text title3 aria-label={hidden ? "***" : `$${credit}`}>
+              <Text aria-hidden secondary>
                 $
               </Text>
-              <Text sensitive aria-hidden title3 emphasized>
-                {(Number(creditLimit) / 1e6).toLocaleString(language, {
-                  minimumFractionDigits: 2,
-                  maximumFractionDigits: 2,
-                })}
+              <Text aria-hidden sensitive emphasized>
+                {credit}
               </Text>
-            </XStack>
+            </Text>
           </XStack>
         </XStack>
       )}


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exactly/exa/pull/905" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Enhanced accessibility labels for spending and credit limit value displays to provide better screen reader support.

* **Display & Localization**
  * Spending and credit limit values now feature improved currency formatting with proper localization support. Sensitive content display has been updated to respect user privacy preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->