### PR TITLE
✨ server: support multi-chain account creation in activity webhook

### DIFF
--- a/.changeset/new-koi-curl.md
+++ b/.changeset/new-koi-curl.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+✨ support multi-chain account creation in activity webhook

--- a/server/hooks/activity.ts
+++ b/server/hooks/activity.ts
@@ -7,6 +7,7 @@ import {
   getTraceData,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   setContext,
+  setTag,
   setUser,
   startSpan,
   withScope,
@@ -15,9 +16,10 @@ import createDebug from "debug";
 import { eq, inArray } from "drizzle-orm";
 import { Hono } from "hono";
 import * as v from "valibot";
-import { bytesToBigInt, hexToBigInt, withRetry } from "viem";
+import { bytesToBigInt, createPublicClient, createWalletClient, hexToBigInt, http, rpcSchema, withRetry } from "viem";
 
-import {
+import alchemyAPIKey from "@exactly/common/alchemyAPIKey";
+import exaChain, {
   auditorAbi,
   exaAccountFactoryAbi,
   exaPluginAbi,
@@ -30,15 +32,16 @@ import {
 import { Address, Hash, Hex } from "@exactly/common/validation";
 
 import database, { cards, credentials } from "../database";
-import { createWebhook, findWebhook, headerValidator, network } from "../utils/alchemy";
+import { createWebhook, findWebhook, headerValidator, NETWORKS } from "../utils/alchemy";
 import appOrigin from "../utils/appOrigin";
 import decodePublicKey from "../utils/decodePublicKey";
-import keeper from "../utils/keeper";
+import keeper, { extender } from "../utils/keeper";
 import { sendPushNotification } from "../utils/onesignal";
 import { autoCredit } from "../utils/panda";
-import publicClient from "../utils/publicClient";
+import publicClient, { captureRequests, Request } from "../utils/publicClient";
 import revertFingerprint from "../utils/revertFingerprint";
 import { track } from "../utils/segment";
+import { trace, type RpcSchema } from "../utils/traceClient";
 import validatorHook from "../utils/validatorHook";
 
 const ETH = v.parse(Address, "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
@@ -61,7 +64,10 @@ export default new Hono().post(
     v.object({
       type: v.literal("ADDRESS_ACTIVITY"),
       event: v.object({
-        network: v.literal(network),
+        network: v.pipe(
+          v.string(),
+          v.check((input) => NETWORKS.has(input), "unsupported network"),
+        ),
         activity: v.array(
           v.intersect([
             v.object({ hash: Hash, fromAddress: Address, toAddress: Address }),
@@ -86,16 +92,18 @@ export default new Hono().post(
     validatorHook({ code: "bad alchemy", status: 200, debug }),
   ),
   async (c) => {
-    setContext("alchemy", await c.req.json());
+    const payload = c.req.valid("json");
+    const chain = NETWORKS.get(payload.event.network);
+    if (!chain) throw new Error("unsupported activity network");
+    setContext("alchemy", payload);
+    setTag("alchemy.network", payload.event.network);
     getActiveSpan()?.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_OP, "alchemy.activity");
-    const transfers = c.req
-      .valid("json")
-      .event.activity.filter(
-        ({ category, rawContract, value }) =>
-          category !== "erc721" &&
-          category !== "erc1155" &&
-          (rawContract?.rawValue && rawContract.rawValue !== "0x" ? hexToBigInt(rawContract.rawValue) > 0n : !!value),
-      );
+    const transfers = payload.event.activity.filter(
+      ({ category, rawContract, value }) =>
+        category !== "erc721" &&
+        category !== "erc1155" &&
+        (rawContract?.rawValue && rawContract.rawValue !== "0x" ? hexToBigInt(rawContract.rawValue) > 0n : !!value),
+    );
     const accounts = await database.query.credentials
       .findMany({
         columns: { account: true, publicKey: true, factory: true, source: true },
@@ -111,9 +119,14 @@ export default new Hono().post(
       );
     if (Object.keys(accounts).length === 1) setUser({ id: v.parse(Address, Object.keys(accounts)[0]) });
 
-    const marketsByAsset = await publicClient
-      .readContract({ address: exaPreviewerAddress, functionName: "assets", abi: exaPreviewerAbi })
-      .then((p) => new Map<Address, Address>(p.map((m) => [v.parse(Address, m.asset), v.parse(Address, m.market)])));
+    const marketsByAsset =
+      chain.id === exaChain.id
+        ? await publicClient
+            .readContract({ address: exaPreviewerAddress, functionName: "assets", abi: exaPreviewerAbi })
+            .then(
+              (p) => new Map<Address, Address>(p.map((m) => [v.parse(Address, m.asset), v.parse(Address, m.market)])),
+            )
+        : new Map<Address, Address>();
     const markets = new Set(marketsByAsset.values());
     const pokes = new Map<
       Address,
@@ -121,15 +134,20 @@ export default new Hono().post(
     >();
     for (const { toAddress: account, rawContract, value, asset: assetSymbol } of transfers) {
       if (!accounts[account]) continue;
-      if (rawContract?.address && markets.has(rawContract.address)) continue;
+      if (chain.id === exaChain.id && rawContract?.address && markets.has(rawContract.address)) continue;
       const asset = rawContract?.address ?? ETH;
       const underlying = asset === ETH ? WETH : asset;
       sendPushNotification({
         userId: account,
         headings: { en: "Funds received" },
-        contents: {
-          en: `${value ? `${value} ` : ""}${assetSymbol} received${marketsByAsset.has(underlying) ? " and instantly started earning yield" : ""}`,
-        },
+        contents:
+          chain.id === exaChain.id && marketsByAsset.has(underlying)
+            ? {
+                en: value
+                  ? `${value} ${assetSymbol} received and instantly started earning yield`
+                  : `${assetSymbol} received and instantly started earning yield`,
+              }
+            : { en: value ? `${value} ${assetSymbol} received` : `${assetSymbol} received` },
       }).catch((error: unknown) => captureException(error));
 
       if (pokes.has(account)) {
@@ -140,6 +158,12 @@ export default new Hono().post(
       }
     }
     const { "sentry-trace": sentryTrace, baggage } = getTraceData();
+    const transport = http(`${chain.rpcUrls.alchemy.http[0]}/${alchemyAPIKey}`, {
+      async onFetchRequest(request) {
+        captureRequests([v.parse(Request, await request.json())]);
+      },
+    });
+    const client = createPublicClient({ chain, transport, rpcSchema: rpcSchema<RpcSchema>() }).extend(trace);
     Promise.allSettled(
       [...pokes].map(([account, { publicKey, factory, source, assets }]) =>
         continueTrace({ sentryTrace, baggage }, () =>
@@ -148,24 +172,31 @@ export default new Hono().post(
               { name: "account activity", op: "exa.activity", attributes: { account }, forceTransaction: true },
               async (span) => {
                 scope.setUser({ id: account });
-                const isDeployed = !!(await publicClient.getCode({ address: account }));
+                const isDeployed = !!(await client.getCode({ address: account }));
                 scope.setTag("exa.new", !isDeployed);
                 if (!isDeployed) {
                   try {
-                    await keeper.exaSend(
-                      { name: "create account", op: "exa.account", attributes: { account } },
-                      {
-                        address: factory,
-                        functionName: "createAccount",
-                        args: [0n, [decodePublicKey(publicKey, bytesToBigInt)]],
-                        abi: exaAccountFactoryAbi,
-                      },
-                    );
+                    await createWalletClient({ chain, transport, account: keeper.account })
+                      .extend((wallet) => extender(wallet, { publicClient: client, traceClient: client }))
+                      .exaSend(
+                        { name: "create account", op: "exa.account", attributes: { account } },
+                        {
+                          address: factory,
+                          functionName: "createAccount",
+                          args: [0n, [decodePublicKey(publicKey, bytesToBigInt)]],
+                          abi: exaAccountFactoryAbi,
+                        },
+                        chain.id === exaChain.id ? undefined : { fees: "auto" },
+                      );
                     track({ event: "AccountFunded", userId: account, properties: { source } });
                   } catch (error: unknown) {
                     span.setStatus({ code: SPAN_STATUS_ERROR, message: "account_failed" });
                     throw error;
                   }
+                }
+                if (chain.id !== exaChain.id) {
+                  span.setStatus({ code: SPAN_STATUS_OK });
+                  return;
                 }
                 if (assets.has(ETH)) assets.delete(WETH);
                 const results = await Promise.allSettled(

--- a/server/test/hooks/activity.test.ts
+++ b/server/test/hooks/activity.test.ts
@@ -6,6 +6,7 @@ import "../mocks/sentry";
 
 import { captureException, setUser } from "@sentry/node";
 import { testClient } from "hono/testing";
+import * as viem from "viem";
 import {
   BaseError,
   bytesToHex,
@@ -28,8 +29,9 @@ import { exaAccountFactoryAbi, previewerAbi } from "@exactly/common/generated/ch
 
 import database, { credentials } from "../../database";
 import app from "../../hooks/activity";
+import { NETWORKS } from "../../utils/alchemy";
 import * as decodePublicKey from "../../utils/decodePublicKey";
-import keeper from "../../utils/keeper";
+import keeper, * as keeperUtilities from "../../utils/keeper";
 import * as onesignal from "../../utils/onesignal";
 import publicClient from "../../utils/publicClient";
 import anvilClient from "../anvilClient";
@@ -56,7 +58,6 @@ describe("address activity", () => {
   });
 
   it("captures no balance once after retries", async () => {
-    vi.spyOn(publicClient, "getCode").mockResolvedValue("0x1");
     vi.spyOn(keeper, "exaSend").mockImplementation((spanOptions) =>
       Promise.resolve(
         spanOptions.op === "exa.poke" ? null : ({ status: "success" } as Awaited<ReturnType<typeof keeper.exaSend>>),
@@ -90,8 +91,11 @@ describe("address activity", () => {
   });
 
   it("fails with unexpected error", async () => {
-    const getCode = vi.spyOn(publicClient, "getCode");
-    getCode.mockRejectedValue(new Error("Unexpected"));
+    const chain = NETWORKS.get("ANVIL");
+    if (!chain) throw new Error("missing anvil");
+    const client = viem.createPublicClient({ chain, transport: viem.http(chain.rpcUrls.alchemy.http[0]) });
+    const getCode = vi.spyOn(client, "getCode").mockRejectedValueOnce(new Error("Unexpected"));
+    vi.mocked(viem.createPublicClient).mockReturnValueOnce(client);
 
     const deposit = parseEther("5");
     await anvilClient.setBalance({ address: account, value: deposit });
@@ -137,10 +141,10 @@ describe("address activity", () => {
       },
     });
 
-    await vi.waitUntil(() => vi.mocked(captureException).mock.calls.length > 0);
+    await vi.waitUntil(() => vi.mocked(captureException).mock.calls.length > 0, 26_666);
 
     expect(captureException).toHaveBeenCalledWith(
-      new WaitForTransactionReceiptTimeoutError({ hash: zeroHash }),
+      expect.objectContaining({ name: "WaitForTransactionReceiptTimeoutError" }),
       expect.objectContaining({ level: "error", fingerprint: ["{{ default }}", "unknown"] }),
     );
     expect(
@@ -178,7 +182,7 @@ describe("address activity", () => {
       },
     });
 
-    await vi.waitUntil(() => vi.mocked(captureException).mock.calls.length > 0);
+    await vi.waitUntil(() => vi.mocked(captureException).mock.calls.length > 0, 26_666);
 
     expect(captureException).toHaveBeenCalledWith(
       expect.any(BaseError),
@@ -213,7 +217,7 @@ describe("address activity", () => {
       },
     });
 
-    await vi.waitUntil(() => vi.mocked(captureException).mock.calls.length > 0);
+    await vi.waitUntil(() => vi.mocked(captureException).mock.calls.length > 0, 26_666);
 
     expect(captureException).toHaveBeenCalledWith(
       expect.any(BaseError),
@@ -246,7 +250,7 @@ describe("address activity", () => {
       },
     });
 
-    await vi.waitUntil(() => vi.mocked(captureException).mock.calls.length > 0);
+    await vi.waitUntil(() => vi.mocked(captureException).mock.calls.length > 0, 26_666);
 
     expect(captureException).toHaveBeenCalledWith(
       expect.any(BaseError),
@@ -285,7 +289,7 @@ describe("address activity", () => {
       },
     });
 
-    await vi.waitUntil(() => vi.mocked(captureException).mock.calls.length > 0);
+    await vi.waitUntil(() => vi.mocked(captureException).mock.calls.length > 0, 26_666);
 
     expect(captureException).toHaveBeenCalledWith(
       expect.any(BaseError),
@@ -299,7 +303,6 @@ describe("address activity", () => {
   });
 
   it("fingerprints shouldRetry by error name", async () => {
-    vi.spyOn(publicClient, "getCode").mockResolvedValue("0x1");
     const revertAbi = [{ type: "error", name: "Unauthorized", inputs: [] }] as const;
     vi.spyOn(publicClient, "simulateContract").mockRejectedValueOnce(
       new BaseError("test", {
@@ -336,7 +339,6 @@ describe("address activity", () => {
   });
 
   it("fingerprints shouldRetry by reason", async () => {
-    vi.spyOn(publicClient, "getCode").mockResolvedValue("0x1");
     vi.spyOn(publicClient, "simulateContract").mockRejectedValueOnce(
       new BaseError("test", {
         cause: new ContractFunctionRevertedError({ abi: [], functionName: "pokeETH", message: "custom reason" }),
@@ -368,7 +370,6 @@ describe("address activity", () => {
   });
 
   it("fingerprints shouldRetry by signature", async () => {
-    vi.spyOn(publicClient, "getCode").mockResolvedValue("0x1");
     vi.spyOn(publicClient, "simulateContract").mockRejectedValueOnce(
       new BaseError("test", {
         cause: new ContractFunctionRevertedError({ abi: [], data: "0xdeadbeef", functionName: "pokeETH" }),
@@ -400,7 +401,6 @@ describe("address activity", () => {
   });
 
   it("fingerprints shouldRetry as unknown revert", async () => {
-    vi.spyOn(publicClient, "getCode").mockResolvedValue("0x1");
     vi.spyOn(publicClient, "simulateContract").mockRejectedValueOnce(
       new BaseError("test", { cause: new ContractFunctionRevertedError({ abi: [], functionName: "pokeETH" }) }),
     );
@@ -430,7 +430,6 @@ describe("address activity", () => {
   });
 
   it("fingerprints shouldRetry as unknown", async () => {
-    vi.spyOn(publicClient, "getCode").mockResolvedValue("0x1");
     vi.spyOn(publicClient, "simulateContract").mockRejectedValueOnce(new Error("unexpected"));
 
     const response = await appClient.index.$post({
@@ -666,7 +665,6 @@ describe("address activity", () => {
   });
 
   it("ignores token without value and zero rawValue", async () => {
-    vi.spyOn(publicClient, "getCode").mockResolvedValue("0x1");
     const exaSend = vi.spyOn(keeper, "exaSend");
     const sendPushNotification = vi.spyOn(onesignal, "sendPushNotification");
 
@@ -706,6 +704,7 @@ describe("address activity", () => {
   });
 
   it("pokes multiple accounts", async () => {
+    const deposit = parseEther("5");
     const owners = [
       owner,
       privateKeyToAccount(generatePrivateKey()),
@@ -715,15 +714,17 @@ describe("address activity", () => {
       deriveAddress(inject("ExaAccountFactory"), { x: padHex(address), y: zeroHash }),
     );
     await Promise.all([
-      ...accounts.slice(1).map((id) =>
-        database.insert(credentials).values({
-          id,
-          publicKey: new Uint8Array(hexToBytes(id)),
-          account: id,
+      ...owners.slice(1).map(({ address }, index) => {
+        const credential = accounts[index + 1];
+        if (!credential) throw new Error("missing account");
+        return database.insert(credentials).values({
+          id: credential,
+          publicKey: new Uint8Array(hexToBytes(address)),
+          account: credential,
           factory: inject("ExaAccountFactory"),
-        }),
-      ),
-      ...accounts.map((address) => anvilClient.setBalance({ address, value: parseEther("5") })),
+        });
+      }),
+      ...accounts.map((address) => anvilClient.setBalance({ address, value: deposit })),
       keeper.exaSend(
         { name: "create account", op: "exa.account" },
         {
@@ -735,8 +736,6 @@ describe("address activity", () => {
       ),
     ]);
 
-    const waitForTransactionReceipt = vi.spyOn(publicClient, "waitForTransactionReceipt");
-    const initialSettledResults = waitForTransactionReceipt.mock.settledResults.length;
     const [response] = await Promise.all([
       appClient.index.$post({
         ...activityPayload,
@@ -748,13 +747,7 @@ describe("address activity", () => {
           },
         },
       }),
-      vi.waitUntil(
-        () =>
-          waitForTransactionReceipt.mock.settledResults
-            .slice(initialSettledResults)
-            .filter(({ type }) => type !== "incomplete").length >= 5,
-        26_666,
-      ),
+      ...accounts.map((address) => waitForWETHMarket(address, deposit)),
     ]);
 
     expect(setUser).not.toHaveBeenCalled();
@@ -780,6 +773,53 @@ describe("address activity", () => {
 
     expect(deployed).toBe(true);
     expect(setUser).toHaveBeenCalledWith({ id: account });
+    expect(response.status).toBe(200);
+  });
+
+  it("deploys on the event network without claiming yield", async () => {
+    const sendPushNotification = vi.spyOn(onesignal, "sendPushNotification");
+    const chain = NETWORKS.get("ANVIL");
+    if (!chain) throw new Error("missing anvil");
+    const client = viem.createPublicClient({ chain, transport: viem.http(chain.rpcUrls.alchemy.http[0]) });
+    const eventGetCode = vi.spyOn(client, "getCode");
+    vi.mocked(viem.createPublicClient).mockReturnValueOnce(client);
+    const eventExaSend = vi.fn<typeof keeper.exaSend>().mockResolvedValue(null);
+    vi.spyOn(keeperUtilities, "extender").mockReturnValueOnce({ exaSend: eventExaSend });
+    const keeperSend = vi.spyOn(keeper, "exaSend");
+
+    const response = await appClient.index.$post({
+      ...activityPayload,
+      json: {
+        ...activityPayload.json,
+        event: {
+          ...activityPayload.json.event,
+          network: "ETH_MAINNET",
+          activity: [
+            {
+              ...activityPayload.json.event.activity[1],
+              toAddress: account,
+              rawContract: { address: inject("WETH") as Address, rawValue: "0x1" },
+            },
+          ],
+        },
+      },
+    });
+
+    await vi.waitUntil(() => eventExaSend.mock.calls.length > 0);
+
+    expect(eventGetCode).toHaveBeenCalledWith({ address: account });
+    expect(eventExaSend).toHaveBeenCalledWith(
+      expect.objectContaining({ attributes: { account }, name: "create account", op: "exa.account" }),
+      expect.objectContaining({
+        abi: exaAccountFactoryAbi,
+        address: inject("ExaAccountFactory") as Address,
+        functionName: "createAccount",
+      }),
+      { fees: "auto" },
+    );
+    expect(keeperSend).not.toHaveBeenCalled();
+    expect(sendPushNotification).toHaveBeenCalled();
+    expect(sendPushNotification.mock.calls[0]?.[0]).toMatchObject({ contents: { en: "99.973 WETH received" } });
     expect(response.status).toBe(200);
   });
 
@@ -896,7 +936,12 @@ const activityPayload = {
   },
 } as const;
 
+vi.mock("@account-kit/infra", { spy: true });
 vi.mock("@sentry/node", { spy: true });
+vi.mock("viem", async (importOriginal) => {
+  const original = await importOriginal<typeof viem>();
+  return { ...original, createPublicClient: vi.fn(original.createPublicClient) };
+});
 
 afterEach(() => {
   vi.clearAllMocks();

--- a/server/utils/alchemy.ts
+++ b/server/utils/alchemy.ts
@@ -1,7 +1,8 @@
+import * as chains from "@account-kit/infra";
 import { validator } from "hono/validator";
-import { array, boolean, object, parse, picklist, string, type InferOutput } from "valibot";
-import { withRetry } from "viem";
-import { anvil, base, baseSepolia, optimism, optimismSepolia } from "viem/chains";
+import { array, boolean, check, object, parse, picklist, pipe, string, type InferOutput } from "valibot";
+import { withRetry, type Chain } from "viem";
+import { anvil } from "viem/chains";
 
 import chain from "@exactly/common/generated/chain";
 
@@ -23,14 +24,9 @@ export function headerValidator(signingKeys: (() => Set<string>) | Set<string>) 
   });
 }
 
-export const network =
-  {
-    [optimism.id]: "OPT_MAINNET" as const,
-    [optimismSepolia.id]: "OPT_SEPOLIA" as const,
-    [base.id]: "BASE_MAINNET" as const,
-    [baseSepolia.id]: "BASE_SEPOLIA" as const,
-    [anvil.id]: "ANVIL" as const,
-  }[chain.id] ?? ("OPT_SEPOLIA" as const);
+export function network(id = chain.id) {
+  return [...NETWORKS].find(([, current]) => current.id === id)?.[0] ?? "OPT_SEPOLIA";
+}
 
 export async function findWebhook(predicate: (webhook: Webhook) => unknown) {
   const webhooks = await withRetry(
@@ -41,7 +37,7 @@ export async function findWebhook(predicate: (webhook: Webhook) => unknown) {
     },
     { retryCount: 10 },
   );
-  return webhooks.find((hook) => hook.is_active && hook.network === network && predicate(hook));
+  return webhooks.find((hook) => hook.is_active && hook.network === network() && predicate(hook));
 }
 
 export async function createWebhook(
@@ -53,7 +49,7 @@ export async function createWebhook(
   const create = await fetch("https://dashboard.alchemy.com/api/create-webhook", {
     headers,
     method: "POST",
-    body: JSON.stringify({ ...options, network }),
+    body: JSON.stringify({ ...options, network: network() }),
   });
   if (!create.ok) throw new ServiceError("Alchemy", create.status, await create.text());
   return parse(WebhookResponse, await create.json()).data;
@@ -71,7 +67,10 @@ export async function updateWebhookAddresses(id: string | undefined, add: Addres
 
 const Webhook = object({
   id: string(),
-  network: picklist(["OPT_MAINNET", "OPT_SEPOLIA", "BASE_MAINNET", "BASE_SEPOLIA"]),
+  network: pipe(
+    string(),
+    check((input) => NETWORKS.has(input), "unsupported network"),
+  ),
   webhook_type: picklist(["GRAPHQL", "ADDRESS_ACTIVITY"]),
   webhook_url: string(),
   signing_key: string(),
@@ -81,3 +80,28 @@ type Webhook = InferOutput<typeof Webhook>;
 
 const WebhookResponse = object({ data: Webhook });
 const WebhooksResponse = object({ data: array(Webhook) });
+
+export const NETWORKS = new Map<string, AlchemyChain>([
+  ["ARB_MAINNET", chains.arbitrum as AlchemyChain],
+  ["ARB_SEPOLIA", chains.arbitrumSepolia as AlchemyChain],
+  ["BASE_MAINNET", chains.base as AlchemyChain],
+  ["BASE_SEPOLIA", chains.baseSepolia as AlchemyChain],
+  ["BNB_MAINNET", chains.bsc as AlchemyChain],
+  ["ETH_MAINNET", chains.mainnet as AlchemyChain],
+  ["ETH_SEPOLIA", chains.sepolia as AlchemyChain],
+  ["INK_MAINNET", chains.inkMainnet as AlchemyChain],
+  ["INK_SEPOLIA", chains.inkSepolia as AlchemyChain],
+  ["MATIC_MAINNET", chains.polygon as AlchemyChain],
+  ["MONAD_MAINNET", chains.monadMainnet as AlchemyChain],
+  ["OPT_MAINNET", chains.optimism as AlchemyChain],
+  ["OPT_SEPOLIA", chains.optimismSepolia as AlchemyChain],
+  ["SHAPE_MAINNET", chains.shape as AlchemyChain],
+  ["SHAPE_SEPOLIA", chains.shapeSepolia as AlchemyChain],
+  ["SONEIUM_MAINNET", chains.soneiumMainnet as AlchemyChain], // cspell:ignore soneium
+  ["SONEIUM_MINATO", chains.soneiumMinato as AlchemyChain], // cspell:ignore minato
+  ["WORLDCHAIN_MAINNET", chains.worldChain as AlchemyChain], // cspell:ignore worldchain
+  ["WORLDCHAIN_SEPOLIA", chains.worldChainSepolia as AlchemyChain],
+  ["ANVIL", { ...anvil, rpcUrls: { ...anvil.rpcUrls, alchemy: anvil.rpcUrls.default } } as AlchemyChain],
+]);
+
+type AlchemyChain = Chain & { rpcUrls: { alchemy: { http: readonly [string] } } };

--- a/server/utils/keeper.ts
+++ b/server/utils/keeper.ts
@@ -12,11 +12,13 @@ import {
   RawContractError,
   WaitForTransactionReceiptTimeoutError,
   withRetry,
-  type HttpTransport,
+  type Chain,
   type MaybePromise,
   type Prettify,
   type PrivateKeyAccount,
+  type PublicActions,
   type TransactionReceipt,
+  type Transport,
   type WalletClient,
   type WriteContractParameters,
 } from "viem";
@@ -28,9 +30,9 @@ import revertReason from "@exactly/common/revertReason";
 import { Address, Hash } from "@exactly/common/validation";
 
 import nonceManager from "./nonceManager";
-import publicClient, { captureRequests, Requests } from "./publicClient";
+import defaultPublicClient, { captureRequests, Requests } from "./publicClient";
 import revertFingerprint from "./revertFingerprint";
-import traceClient from "./traceClient";
+import defaultTraceClient from "./traceClient";
 
 if (!chain.rpcUrls.alchemy.http[0]) throw new Error("missing alchemy rpc url");
 
@@ -50,12 +52,25 @@ export default createWalletClient({
   ),
 }).extend(extender);
 
-export function extender(keeper: WalletClient<HttpTransport, typeof chain, PrivateKeyAccount>) {
+export function extender(
+  keeper: WalletClient<Transport, Chain, PrivateKeyAccount>,
+  {
+    publicClient = defaultPublicClient,
+    traceClient = defaultTraceClient,
+  }: {
+    publicClient?: Pick<
+      PublicActions<Transport, Chain>,
+      "sendRawTransaction" | "simulateContract" | "waitForTransactionReceipt"
+    >;
+    traceClient?: Pick<typeof defaultTraceClient, "traceTransaction">;
+  } = {},
+) {
   return {
     exaSend: async (
       spanOptions: Prettify<Omit<Parameters<typeof startSpan>[0], "name" | "op"> & { name: string; op: string }>,
       call: Prettify<Pick<WriteContractParameters, "abi" | "address" | "args" | "functionName">>,
       options?: {
+        fees?: "auto";
         ignore?: ((reason: string) => MaybePromise<boolean | TransactionReceipt | undefined>) | string[];
         level?: "error" | "warning" | ((reason: string, error: unknown) => "error" | "warning" | false) | false;
         onHash?: (hash: Hash) => MaybePromise<unknown>;
@@ -74,9 +89,11 @@ export function extender(keeper: WalletClient<HttpTransport, typeof chain, Priva
             });
             const txOptions = {
               type: "eip1559",
-              maxFeePerGas: 1_000_000_000n,
-              maxPriorityFeePerGas: 1_000_000n,
               gas: 5_000_000n,
+              ...(options?.fees !== "auto" && {
+                maxFeePerGas: 1_000_000_000n,
+                maxPriorityFeePerGas: 1_000_000n,
+              }),
             } as const;
             const { request: writeRequest } = await startSpan({ name: "eth_call", op: "tx.simulate" }, () =>
               publicClient.simulateContract({ account: keeper.account, ...txOptions, ...call }),
@@ -127,11 +144,11 @@ export function extender(keeper: WalletClient<HttpTransport, typeof chain, Priva
                     startSpan(
                       { name: "nonce reset", op: "tx.reset", attributes: { "tx.nonce": prepared.nonce } },
                       (resetSpan) => {
-                        const info = nonceManager.info({ address: keeper.account.address, chainId: chain.id });
+                        const info = nonceManager.info({ address: keeper.account.address, chainId: keeper.chain.id });
                         resetSpan.setAttribute("exa.reset", true);
                         resetSpan.setAttribute("exa.delta", info.delta);
                         resetSpan.setAttribute("exa.nonce", info.nonce);
-                        nonceManager.hardReset({ address: keeper.account.address, chainId: chain.id });
+                        nonceManager.hardReset({ address: keeper.account.address, chainId: keeper.chain.id });
                       },
                     );
                   }

--- a/server/utils/traceClient.ts
+++ b/server/utils/traceClient.ts
@@ -13,6 +13,8 @@ import {
   type BlockNumber,
   type BlockTag,
   type CallParameters,
+  type Chain,
+  type Client,
   type FormattedTransactionRequest,
   type Hash,
   type Hex,
@@ -23,6 +25,7 @@ import {
   type RpcTransactionRequest,
   type StateMapping,
   type StateOverride,
+  type Transport,
 } from "viem";
 
 import alchemyAPIKey from "@exactly/common/alchemyAPIKey";
@@ -32,15 +35,7 @@ import { captureRequests, Request } from "./publicClient";
 
 if (!chain.rpcUrls.alchemy.http[0]) throw new Error("missing alchemy rpc url");
 
-export default createPublicClient({
-  chain,
-  rpcSchema: rpcSchema<RpcSchema>(),
-  transport: http(`${chain.rpcUrls.alchemy.http[0]}/${alchemyAPIKey}`, {
-    async onFetchRequest(request) {
-      captureRequests([parse(Request, await request.json())]);
-    },
-  }),
-}).extend((client) => ({
+export const trace = (client: Pick<Client<Transport, Chain | undefined, undefined, RpcSchema>, "request">) => ({
   traceCall: async ({
     blockNumber,
     blockTag = "latest",
@@ -63,7 +58,17 @@ export default createPublicClient({
       method: "debug_traceTransaction",
       params: [hash, { tracer: "callTracer", tracerConfig: { withLog: true } }],
     }),
-}));
+});
+
+export default createPublicClient({
+  chain,
+  rpcSchema: rpcSchema<RpcSchema>(),
+  transport: http(`${chain.rpcUrls.alchemy.http[0]}/${alchemyAPIKey}`, {
+    async onFetchRequest(request) {
+      captureRequests([parse(Request, await request.json())]);
+    },
+  }),
+}).extend(trace);
 
 export type CallFrame = {
   calls?: CallFrame[];


### PR DESCRIPTION
closes #960 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-chain support for account creation via the activity webhook; deployments can run on the event network.

* **Bug Fixes**
  * Runtime validation of event networks with clear rejection of unsupported networks.
  * Market, notification and auto-credit behavior now respect the resolved chain (yield messaging skipped off the primary chain).

* **Tests**
  * Added/updated tests for multi-chain deployment flows, event-network deployments, and error handling.

* **Refactor**
  * Per-chain RPC/tracing and client wiring reorganized for chain-specific execution and extensibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->