### PR TITLE
🐛 app: route owner rpc through alchemy

### DIFF
--- a/.changeset/chubby-flowers-learn.md
+++ b/.changeset/chubby-flowers-learn.md
@@ -1,0 +1,5 @@
+---
+"@exactly/mobile": patch
+---
+
+🐛 route owner rpc through alchemy

--- a/src/utils/wagmi/owner.ts
+++ b/src/utils/wagmi/owner.ts
@@ -1,11 +1,13 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 
+import * as infra from "@account-kit/infra";
 import { sdk } from "@farcaster/miniapp-sdk";
 import { farcasterMiniApp as miniAppConnector } from "@farcaster/miniapp-wagmi-connector";
 import { http } from "viem";
 import * as chains from "viem/chains";
 import { createConfig, createStorage, custom, injected } from "wagmi";
 
+import alchemyAPIKey from "@exactly/common/alchemyAPIKey";
 import chain from "@exactly/common/generated/chain";
 
 import publicClient from "../publicClient";
@@ -15,6 +17,14 @@ const config = createConfig({
   connectors: [miniAppConnector(), injected()],
   transports: {
     ...Object.fromEntries(Object.values(chains).map((c) => [c.id, http()])),
+    ...Object.values(infra).reduce<Record<number, ReturnType<typeof http>>>((result, item) => {
+      if (typeof item !== "object" || !("id" in item) || !("rpcUrls" in item)) return result;
+      const c = item as { id: number; rpcUrls: { alchemy?: { http?: readonly string[] } } };
+      const url = c.rpcUrls.alchemy?.http?.[0];
+      if (!url) return result;
+      result[c.id] = http(`${url}/${alchemyAPIKey}`);
+      return result;
+    }, {}),
     [chain.id]: custom(publicClient),
   },
   storage: createStorage({ key: "wagmi.owner", storage: AsyncStorage }),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Owner RPC routing now uses Alchemy-backed endpoints to improve network reliability and transaction processing.
  * Patch release entry added to mark the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->