### PR TITLE
🥅 app: exclude declined card entries from activity

### DIFF
--- a/.changeset/easy-pears-wonder.md
+++ b/.changeset/easy-pears-wonder.md
@@ -1,0 +1,5 @@
+---
+"@exactly/mobile": patch
+---
+
+🥅 exclude declined card entries from activity

--- a/src/utils/server.ts
+++ b/src/utils/server.ts
@@ -276,7 +276,7 @@ async function getActivity(
   }
   const activity = await parseResponse(response);
   if (typeof activity === "string" || activity instanceof Uint8Array) throw new Error("bad activity response");
-  return activity;
+  return activity.filter((item) => !("status" in item && item.status === "declined"));
 }
 queryClient.setQueryDefaults(["activity"], { staleTime: 60_000, gcTime: 60 * 60_000, queryFn: () => getActivity() });
 queryClient.setQueryDefaults(["activity", "card"], {


### PR DESCRIPTION
closes #887 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Activity feed now omits declined card transactions, so declined entries no longer appear in your activity history.
  * Improves clarity of transaction history by removing irrelevant declined items, making it easier to review actual card activity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/exactly/exa/pull/1022?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->