### PR TITLE
🚑 server: drop unused payment rails field

### DIFF
--- a/.changeset/easy-teeth-flow.md
+++ b/.changeset/easy-teeth-flow.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+🚑 drop unused payment rails field

--- a/server/test/utils/bridge.test.ts
+++ b/server/test/utils/bridge.test.ts
@@ -2160,7 +2160,6 @@ function usdVirtualAccount(account: string) {
     status: "activated",
     source_deposit_instructions: {
       currency: "usd",
-      payment_rails: ["ach_push", "wire"],
       bank_name: "Test Bank",
       bank_address: "123 Bank St",
       bank_routing_number: "111000025",
@@ -2178,7 +2177,6 @@ function eurVirtualAccount(account: string) {
     status: "activated",
     source_deposit_instructions: {
       currency: "eur",
-      payment_rails: ["sepa"],
       bank_name: "EU Bank",
       bank_address: "789 EU St",
       account_holder_name: "Test Holder",
@@ -2195,7 +2193,6 @@ function mxnVirtualAccount(account: string) {
     status: "activated",
     source_deposit_instructions: {
       currency: "mxn",
-      payment_rails: ["spei"],
       account_holder_name: "Test Holder MX",
       clabe: "646180171800000178", // cspell:ignore clabe
     },
@@ -2209,7 +2206,6 @@ function brlVirtualAccount(account: string) {
     status: "activated",
     source_deposit_instructions: {
       currency: "brl",
-      payment_rails: ["pix"],
       account_holder_name: "Test Holder BR",
       br_code: "00020126580014br.gov.bcb.pix", // cspell:ignore bcb
     },
@@ -2223,7 +2219,6 @@ function gbpVirtualAccount(account: string) {
     status: "activated",
     source_deposit_instructions: {
       currency: "gbp",
-      payment_rails: ["faster_payments"],
       account_number: "12345678",
       sort_code: "123456",
       account_holder_name: "Test Holder GB",

--- a/server/utils/ramps/bridge.ts
+++ b/server/utils/ramps/bridge.ts
@@ -520,7 +520,6 @@ function containsRequirement(node: unknown, targets: Set<string>): boolean {
 const Endorsements = ["base", "faster_payments", "pix", "sepa", "spei"] as const; // cspell:ignore spei, sepa
 export const BridgeCurrency = ["brl", "eur", "gbp", "mxn", "usd", "usdc", "usdt"] as const;
 
-export const PaymentRail = ["ach_push", "faster_payments", "pix", "sepa", "spei", "wire"] as const;
 const VirtualAccountStatus = ["activated", "deactivated"] as const;
 
 export const FiatCurrency = ["BRL", "EUR", "GBP", "MXN", "USD"] as const;
@@ -843,13 +842,11 @@ const VirtualAccount = object({
   source_deposit_instructions: variant("currency", [
     object({
       currency: literal("brl" as const satisfies (typeof BridgeCurrency)[number]),
-      payment_rails: array(picklist(["pix"] as const satisfies (typeof PaymentRail)[number][])),
       account_holder_name: string(),
       br_code: string(),
     }),
     object({
       currency: literal("usd" as const satisfies (typeof BridgeCurrency)[number]),
-      payment_rails: array(picklist(["ach_push", "wire"] as const satisfies (typeof PaymentRail)[number][])),
       bank_name: string(),
       bank_address: string(),
       bank_routing_number: string(),
@@ -859,7 +856,6 @@ const VirtualAccount = object({
     }),
     object({
       currency: literal("eur" as const satisfies (typeof BridgeCurrency)[number]),
-      payment_rails: array(picklist(["sepa"] as const satisfies (typeof PaymentRail)[number][])),
       bank_name: string(),
       bank_address: string(),
       account_holder_name: string(),
@@ -868,13 +864,11 @@ const VirtualAccount = object({
     }),
     object({
       currency: literal("mxn" as const satisfies (typeof BridgeCurrency)[number]),
-      payment_rails: array(picklist(["spei"] as const satisfies (typeof PaymentRail)[number][])),
       account_holder_name: string(),
       clabe: string(), // cspell:ignore clabe
     }),
     object({
       currency: literal("gbp" as const satisfies (typeof BridgeCurrency)[number]),
-      payment_rails: array(picklist(["faster_payments"] as const satisfies (typeof PaymentRail)[number][])),
       account_number: string(),
       sort_code: string(),
       account_holder_name: string(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified payment instruction validation by removing an unused field across several currency corridors.

* **Tests**
  * Updated test fixtures to match the revised validation schema.

* **Chores**
  * Added release metadata noting the patch-level update.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/exactly/exa/pull/1025?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->