### PR TITLE
✨ server: add rejection code to authorization declines

### DIFF
--- a/.changeset/brisk-otter-tag.md
+++ b/.changeset/brisk-otter-tag.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+✨ add rejection code to authorization declines

--- a/server/hooks/panda.ts
+++ b/server/hooks/panda.ts
@@ -294,7 +294,9 @@ export default new Hono().post(
           where: eq(cards.id, payload.body.spend.cardId),
           with: { credential: { columns: { account: true, id: true, source: true } } },
         });
-        if (!card) return c.json({ code: "card not found" }, 404);
+        if (!card) {
+          return c.json({ code: "card not found", rejectionCode: "UNKNOWN" }, 404);
+        }
 
         const account = v.parse(Address, card.credential.account);
         setUser({ id: account });
@@ -304,12 +306,12 @@ export default new Hono().post(
 
           await reject(account, payload, jsonBody, "frozenCard");
 
-          return c.json({ code: "frozen card" }, 403 as UnofficialStatusCode);
+          return c.json({ code: "frozen card", rejectionCode: "NOT_PERMITTED" }, 403 as UnofficialStatusCode);
         }
 
         if (card.status !== "ACTIVE") {
           trackAuthorizationRejected(account, payload, card.mode, card.credential.source, "card-not-active");
-          return c.json({ code: "card not active" }, 403);
+          return c.json({ code: "card not active", rejectionCode: "NOT_PERMITTED" }, 403);
         }
         const assess = () => {
           return risk({
@@ -357,7 +359,7 @@ export default new Hono().post(
           if (error === E_TIMEOUT) {
             captureException(error, { level: "fatal", tags: { unhandled: true } });
             trackAuthorizationRejected(account, payload, card.mode, card.credential.source, "mutex-timeout");
-            return c.json({ code: "mutex timeout" }, 554 as UnofficialStatusCode);
+            return c.json({ code: "mutex timeout", rejectionCode: "UNKNOWN" }, 554 as UnofficialStatusCode);
           }
           trackAuthorizationRejected(account, payload, card.mode, card.credential.source, "unknown-error");
           throw error;
@@ -444,7 +446,11 @@ export default new Hono().post(
               if (contractError instanceof BaseError && contractError.cause instanceof ContractFunctionRevertedError) {
                 switch (contractError.cause.data?.errorName) {
                   case "InsufficientAccountLiquidity":
-                    throw new PandaError("InsufficientAccountLiquidity", 557 as UnofficialStatusCode);
+                    throw new PandaError(
+                      "InsufficientAccountLiquidity",
+                      557 as UnofficialStatusCode,
+                      "INSUFFICIENT_FUNDS",
+                    );
                   case "Replay":
                     throw new PandaError("Replay", 558 as UnofficialStatusCode);
                 }
@@ -496,14 +502,17 @@ export default new Hono().post(
               await reject(account, payload, jsonBody, error.message);
             }
 
-            return c.json({ code: error.message }, error.statusCode as UnofficialStatusCode);
+            return c.json(
+              { code: error.message, rejectionCode: error.rejectionCode },
+              error.statusCode as UnofficialStatusCode,
+            );
           }
           trackAuthorizationRejected(account, payload, card.mode, card.credential.source, "unexpected-error");
           captureException(error, { level: "error", tags: { unhandled: true } });
 
           await reject(account, payload, jsonBody, error instanceof Error ? error.message : "unexpected error");
 
-          return c.json({ code: "ouch" }, 569 as UnofficialStatusCode);
+          return c.json({ code: "ouch", rejectionCode: "UNKNOWN" }, 569 as UnofficialStatusCode);
         }
       }
       case "completed":
@@ -1302,6 +1311,7 @@ class PandaError extends Error {
   constructor(
     message: string,
     public statusCode: number,
+    public rejectionCode: "INSUFFICIENT_FUNDS" | "NOT_PERMITTED" | "UNKNOWN" = "UNKNOWN",
   ) {
     super(message);
     this.name = "PandaError";

--- a/server/test/hooks/panda.test.ts
+++ b/server/test/hooks/panda.test.ts
@@ -128,6 +128,10 @@ describe("card operations", () => {
         });
 
         expect(response.status).toBe(557);
+        await expect(response.json()).resolves.toStrictEqual({
+          code: "InsufficientAccountLiquidity",
+          rejectionCode: "INSUFFICIENT_FUNDS",
+        });
         expect(captureException).not.toHaveBeenCalled();
       });
 
@@ -148,10 +152,70 @@ describe("card operations", () => {
         });
 
         expect(response.status).toBe(558);
+        await expect(response.json()).resolves.toStrictEqual({
+          code: "Replay",
+          rejectionCode: "UNKNOWN",
+        });
         expect(captureException).toHaveBeenCalledWith(
           expect.objectContaining({ message: "Replay" }),
           expect.objectContaining({ level: "error", tags: { unhandled: true } }),
         );
+      });
+
+      it("fails with card not found", async () => {
+        const response = await appClient.index.$post({
+          ...authorization,
+          json: {
+            ...authorization.json,
+            body: { ...authorization.json.body, spend: { ...authorization.json.body.spend, cardId: "rc-missing" } },
+          },
+        });
+
+        expect(response.status).toBe(404);
+        await expect(response.json()).resolves.toStrictEqual({
+          code: "card not found",
+          rejectionCode: "UNKNOWN",
+        });
+      });
+
+      it("fails with frozen card", async () => {
+        const cardId = "rc-frozen";
+        await database.insert(cards).values([{ id: cardId, credentialId: "cred", lastFour: "0001", status: "FROZEN" }]);
+
+        const response = await appClient.index.$post({
+          ...authorization,
+          json: {
+            ...authorization.json,
+            body: { ...authorization.json.body, spend: { ...authorization.json.body.spend, cardId } },
+          },
+        });
+
+        expect(response.status).toBe(403);
+        await expect(response.json()).resolves.toStrictEqual({
+          code: "frozen card",
+          rejectionCode: "NOT_PERMITTED",
+        });
+      });
+
+      it("fails with inactive card", async () => {
+        const cardId = "rc-deleted";
+        await database
+          .insert(cards)
+          .values([{ id: cardId, credentialId: "cred", lastFour: "0002", status: "DELETED" }]);
+
+        const response = await appClient.index.$post({
+          ...authorization,
+          json: {
+            ...authorization.json,
+            body: { ...authorization.json.body, spend: { ...authorization.json.body.spend, cardId } },
+          },
+        });
+
+        expect(response.status).toBe(403);
+        await expect(response.json()).resolves.toStrictEqual({
+          code: "card not active",
+          rejectionCode: "NOT_PERMITTED",
+        });
       });
 
       it("fails with bad panda", async () => {
@@ -309,6 +373,74 @@ describe("card operations", () => {
           expect.objectContaining({ level: "error", tags: { unhandled: true } }),
         );
         expect(response.status).toBe(550);
+        await expect(response.json()).resolves.toStrictEqual({
+          code: "tx reverted",
+          rejectionCode: "UNKNOWN",
+        });
+      });
+
+      it("fails with bad collection", async () => {
+        vi.spyOn(traceClient, "traceCall").mockResolvedValueOnce({ ...callFrame });
+        const cardId = "rc-bad-collection";
+        await database.insert(cards).values([{ id: cardId, credentialId: "cred", lastFour: "0004", mode: 0 }]);
+
+        const response = await appClient.index.$post({
+          ...authorization,
+          json: {
+            ...authorization.json,
+            body: { ...authorization.json.body, spend: { ...authorization.json.body.spend, cardId } },
+          },
+        });
+
+        expect(response.status).toBe(551);
+        await expect(response.json()).resolves.toStrictEqual({
+          code: "bad collection",
+          rejectionCode: "UNKNOWN",
+        });
+      });
+
+      it("fails with mutex timeout", async () => {
+        const cardId = "rc-mutex";
+        await database.insert(cards).values([{ id: cardId, credentialId: "cred", lastFour: "0003" }]);
+        const mutex = panda.createMutex(account);
+        await mutex.acquire();
+        try {
+          const response = await appClient.index.$post({
+            ...authorization,
+            json: {
+              ...authorization.json,
+              body: { ...authorization.json.body, spend: { ...authorization.json.body.spend, cardId } },
+            },
+          });
+
+          expect(response.status).toBe(554);
+          await expect(response.json()).resolves.toStrictEqual({
+            code: "mutex timeout",
+            rejectionCode: "UNKNOWN",
+          });
+        } finally {
+          mutex.release();
+        }
+      });
+
+      it("fails with unexpected outer-catch error", async () => {
+        vi.spyOn(panda, "signIssuerOp").mockRejectedValueOnce(new Error("sign failed"));
+        const cardId = "rc-ouch";
+        await database.insert(cards).values([{ id: cardId, credentialId: "cred", lastFour: "0005", mode: 0 }]);
+
+        const response = await appClient.index.$post({
+          ...authorization,
+          json: {
+            ...authorization.json,
+            body: { ...authorization.json.body, spend: { ...authorization.json.body.spend, cardId } },
+          },
+        });
+
+        expect(response.status).toBe(569);
+        await expect(response.json()).resolves.toStrictEqual({
+          code: "ouch",
+          rejectionCode: "UNKNOWN",
+        });
       });
 
       it("alarms high risk authorization", async () => {
@@ -2812,6 +2944,10 @@ describe("concurrency", () => {
       });
 
       expect(response.status).toBe(569);
+      await expect(response.json()).resolves.toStrictEqual({
+        code: "unexpected error",
+        rejectionCode: "UNKNOWN",
+      });
       expect(sendPushNotificationSpy).not.toHaveBeenCalled();
     });
   });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Authorization declines now include structured rejection codes in error responses, providing clearer feedback for scenarios such as insufficient funds, frozen accounts, and permission denials.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/exactly/exa/pull/1051?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->