### PR TITLE
🔒️ server: restrict bridge access by country

### DIFF
--- a/.changeset/wary-falcon-guard.md
+++ b/.changeset/wary-falcon-guard.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+🔒️ restrict bridge access by country

--- a/server/api/ramp.ts
+++ b/server/api/ramp.ts
@@ -218,6 +218,7 @@ export default new Hono()
             if (error instanceof Error && Object.values(bridge.ErrorCodes).includes(error.message)) {
               switch (error.message) {
                 case bridge.ErrorCodes.ALREADY_ONBOARDED:
+                case bridge.ErrorCodes.DENYLISTED_COUNTRY:
                   return c.json({ code: error.message }, 400);
                 case bridge.ErrorCodes.INVALID_ADDRESS: {
                   const { inquiryId, sessionToken } = await getOrCreateInquiry(credentialId, ADDRESS_TEMPLATE);

--- a/server/test/api/ramp.test.ts
+++ b/server/test/api/ramp.test.ts
@@ -816,6 +816,18 @@ describe("ramp api", () => {
         await expect(response.json()).resolves.toStrictEqual({ code: "already onboarded" });
       });
 
+      it("returns 400 when country is denylisted", async () => {
+        vi.spyOn(bridge, "onboarding").mockRejectedValue(new Error(bridge.ErrorCodes.DENYLISTED_COUNTRY));
+
+        const response = await appClient.index.$post(
+          { json: { provider: "bridge", acceptedTermsId: "terms_123" } },
+          { headers: { "test-credential-id": "ramp-bridge" } },
+        );
+
+        expect(response.status).toBe(400);
+        await expect(response.json()).resolves.toStrictEqual({ code: "denylisted country" });
+      });
+
       it("returns 400 with new inquiry for invalid address when no existing inquiry", async () => {
         vi.spyOn(bridge, "onboarding").mockRejectedValue(new Error(bridge.ErrorCodes.INVALID_ADDRESS));
         vi.spyOn(persona, "getInquiry").mockResolvedValue(undefined); // eslint-disable-line unicorn/no-useless-undefined

--- a/server/test/utils/bridge.test.ts
+++ b/server/test/utils/bridge.test.ts
@@ -1091,6 +1091,19 @@ describe("bridge utils", () => {
         await expect(bridge.getProvider({ credentialId: "cred-1" })).rejects.toThrow(bridge.ErrorCodes.NO_DOCUMENT);
       });
 
+      it("returns NOT_AVAILABLE when country is denylisted", async () => {
+        const fetchSpy = vi.spyOn(globalThis, "fetch");
+        vi.spyOn(persona, "getAccount").mockResolvedValueOnce({
+          ...personaAccount,
+          attributes: { ...personaAccount.attributes, "country-code": "ID" },
+        });
+
+        const result = await bridge.getProvider({ credentialId: "cred-1" });
+
+        expect(result).toStrictEqual({ onramp: { currencies: [] }, status: "NOT_AVAILABLE" });
+        expect(fetchSpy).not.toHaveBeenCalled();
+      });
+
       it("returns NOT_AVAILABLE when id class is not mappable to bridge type", async () => {
         vi.spyOn(persona, "getAccount").mockResolvedValueOnce(personaAccount);
         vi.spyOn(persona, "getDocumentForBridge").mockReturnValueOnce({
@@ -1297,6 +1310,26 @@ describe("bridge utils", () => {
       await expect(
         bridge.onboarding({ credentialId: "cred-1", customerId: null, acceptedTermsId: "terms-1" }),
       ).rejects.toThrow(bridge.ErrorCodes.NO_DOCUMENT);
+    });
+
+    it("throws DENYLISTED_COUNTRY when country is denylisted", async () => {
+      vi.spyOn(persona, "getAccount").mockResolvedValueOnce({
+        ...personaAccount,
+        attributes: { ...personaAccount.attributes, "country-code": "ID" },
+      });
+      const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+      await expect(
+        bridge.onboarding({ credentialId: "cred-1", customerId: null, acceptedTermsId: "terms-1" }),
+      ).rejects.toThrow(bridge.ErrorCodes.DENYLISTED_COUNTRY);
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(captureException).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "bridge denylisted country" }),
+        expect.objectContaining({
+          contexts: { bridge: { credentialId: "cred-1", countryCode: "ID" } },
+          level: "warning",
+        }),
+      );
     });
 
     it("throws when front document photo is missing", async () => {

--- a/server/utils/ramps/bridge.ts
+++ b/server/utils/ramps/bridge.ts
@@ -265,6 +265,9 @@ export async function getProvider(params: {
   if (!personaAccount) throw new Error(ErrorCodes.NO_PERSONA_ACCOUNT);
 
   const countryCode = personaAccount.attributes["country-code"];
+  if (Denylist.has(countryCode)) {
+    return { onramp: { currencies: [] }, status: "NOT_AVAILABLE" as const };
+  }
   const validDocument = persona.getDocumentForBridge(personaAccount.attributes.fields.documents.value);
   if (!validDocument) throw new Error(ErrorCodes.NO_DOCUMENT);
   const idClass = safeParse(picklist(persona.IdentificationClasses), validDocument.id_class.value);
@@ -320,6 +323,13 @@ export async function onboarding(params: { acceptedTermsId: string; credentialId
   if (!personaAccount) throw new Error(ErrorCodes.NO_PERSONA_ACCOUNT);
 
   const countryCode = personaAccount.attributes["country-code"];
+  if (Denylist.has(countryCode)) {
+    captureException(new Error("bridge denylisted country"), {
+      contexts: { bridge: { credentialId: params.credentialId, countryCode } },
+      level: "warning",
+    });
+    throw new Error(ErrorCodes.DENYLISTED_COUNTRY);
+  }
 
   const validDocument = persona.getDocumentForBridge(personaAccount.attributes.fields.documents.value);
   if (!validDocument) throw new Error(ErrorCodes.NO_DOCUMENT);
@@ -517,6 +527,7 @@ function containsRequirement(node: unknown, targets: Set<string>): boolean {
   return false;
 }
 
+const Denylist = new Set(["ID"]);
 const Endorsements = ["base", "faster_payments", "pix", "sepa", "spei"] as const; // cspell:ignore spei, sepa
 export const BridgeCurrency = ["brl", "eur", "gbp", "mxn", "usd", "usdc", "usdt"] as const;
 
@@ -1085,6 +1096,7 @@ function getDepositDetailsFromLiquidationAddress(
 export const ErrorCodes = {
   ALREADY_ONBOARDED: "already onboarded",
   BAD_BRIDGE_ID: "bad bridge id",
+  DENYLISTED_COUNTRY: "denylisted country",
   EMAIL_ALREADY_EXISTS: "email already exists",
   INVALID_ACCOUNT: "invalid destination account",
   INVALID_ADDRESS: "invalid address",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bridge provider onboarding now enforces geographic restrictions. Users attempting to onboard from denylisted countries will receive a clear error response.

* **Tests**
  * Added test coverage for country-based access restrictions, including error handling and provider unavailability scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->