### PR TITLE
🐛 server: fix bridge schema for non-us external accounts

### DIFF
--- a/.changeset/brave-heron-waves.md
+++ b/.changeset/brave-heron-waves.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+🐛 fix bridge schema for non-us external accounts

--- a/server/api/ramp.ts
+++ b/server/api/ramp.ts
@@ -34,13 +34,16 @@ import * as manteca from "../utils/ramps/manteca";
 import validatorHook from "../utils/validatorHook";
 
 const ErrorCodes = {
+  EXTERNAL_ACCOUNT_ALREADY_EXISTS: "external account already exists",
   EXTERNAL_ACCOUNT_CURRENCY_MISMATCH: "external account currency mismatch",
   EXTERNAL_ACCOUNT_NOT_FOUND: "external account not found",
   EXTERNAL_ACCOUNT_NOT_SUPPORTED: "external account not supported",
+  INVALID_BANK_NAME: "invalid bank name",
   INVALID_DEPOSIT_ADDRESS: "invalid deposit address",
   NO_CREDENTIAL: "no credential",
   NOT_APPROVED: "not approved",
   NOT_STARTED: "not started",
+  POSTAL_CODE_REQUIRED: "postal code required",
   WITHDRAWAL_IN_PROGRESS: "withdrawal in progress",
 };
 
@@ -379,6 +382,15 @@ export default new Hono()
     } catch (error) {
       if (error instanceof Error && error.message === bridge.ErrorCodes.NO_ENDORSEMENT) {
         return c.json({ code: ErrorCodes.NOT_APPROVED }, 400);
+      }
+      if (error instanceof Error && error.message === bridge.ErrorCodes.INVALID_BANK_NAME) {
+        return c.json({ code: ErrorCodes.INVALID_BANK_NAME }, 400);
+      }
+      if (error instanceof Error && error.message === bridge.ErrorCodes.POSTAL_CODE_REQUIRED) {
+        return c.json({ code: ErrorCodes.POSTAL_CODE_REQUIRED }, 400);
+      }
+      if (error instanceof Error && error.message === bridge.ErrorCodes.EXTERNAL_ACCOUNT_ALREADY_EXISTS) {
+        return c.json({ code: ErrorCodes.EXTERNAL_ACCOUNT_ALREADY_EXISTS }, 400);
       }
       throw error;
     }

--- a/server/test/api/ramp.test.ts
+++ b/server/test/api/ramp.test.ts
@@ -1220,6 +1220,353 @@ describe("ramp api", () => {
     });
   });
 
+  describe("create external account", () => {
+    const input = {
+      currency: "USD" as const,
+      accountOwnerName: "John Doe",
+      accountNumber: "1210002481111",
+      routingNumber: "121000248",
+      address: { streetLine1: "123 Main St", city: "Anytown", state: "CA", country: "USA" }, // cspell:ignore anytown
+    };
+
+    it("returns 400 for no credential", async () => {
+      const response = await appClient["external-account"].$post(
+        { json: input },
+        { headers: { "test-credential-id": "non-existent" } },
+      );
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toStrictEqual({ code: "no credential" });
+    });
+
+    it("returns 400 when bridgeId is missing", async () => {
+      const response = await appClient["external-account"].$post(
+        { json: input },
+        { headers: { "test-credential-id": "ramp-test" } },
+      );
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toStrictEqual({ code: "not started" });
+    });
+
+    it("returns 400 when bridge customer not found", async () => {
+      vi.spyOn(bridge, "getCustomer").mockResolvedValue(undefined); // eslint-disable-line unicorn/no-useless-undefined
+      const createSpy = vi.spyOn(bridge, "createExternalAccount");
+
+      const response = await appClient["external-account"].$post(
+        { json: input },
+        { headers: { "test-credential-id": "ramp-bridge" } },
+      );
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toStrictEqual({ code: "not started" });
+      expect(createSpy).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 when customer is not active", async () => {
+      vi.spyOn(bridge, "getCustomer").mockResolvedValue({ ...bridgeCustomer, status: "under_review" });
+      const createSpy = vi.spyOn(bridge, "createExternalAccount");
+
+      const response = await appClient["external-account"].$post(
+        { json: input },
+        { headers: { "test-credential-id": "ramp-bridge" } },
+      );
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toStrictEqual({ code: "not approved" });
+      expect(createSpy).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 for input without account details", async () => {
+      const createSpy = vi.spyOn(bridge, "createExternalAccount");
+
+      const response = await appClient["external-account"].$post(
+        { json: { currency: "USD" } as never },
+        { headers: { "test-credential-id": "ramp-bridge" } },
+      );
+
+      expect(response.status).toBe(400);
+      expect(createSpy).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 when the customer lacks the required endorsement", async () => {
+      vi.spyOn(bridge, "getCustomer").mockResolvedValue(bridgeCustomer);
+      vi.spyOn(bridge, "createExternalAccount").mockRejectedValue(new Error(bridge.ErrorCodes.NO_ENDORSEMENT));
+
+      const response = await appClient["external-account"].$post(
+        { json: input },
+        { headers: { "test-credential-id": "ramp-bridge" } },
+      );
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toStrictEqual({ code: "not approved" });
+    });
+
+    it("returns 400 when bridge cannot determine the bank name", async () => {
+      vi.spyOn(bridge, "getCustomer").mockResolvedValue(bridgeCustomer);
+      vi.spyOn(bridge, "createExternalAccount").mockRejectedValue(new Error(bridge.ErrorCodes.INVALID_BANK_NAME));
+
+      const response = await appClient["external-account"].$post(
+        { json: input },
+        { headers: { "test-credential-id": "ramp-bridge" } },
+      );
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toStrictEqual({ code: "invalid bank name" });
+    });
+
+    it("returns 400 when bridge requires the postal code", async () => {
+      vi.spyOn(bridge, "getCustomer").mockResolvedValue(bridgeCustomer);
+      vi.spyOn(bridge, "createExternalAccount").mockRejectedValue(new Error(bridge.ErrorCodes.POSTAL_CODE_REQUIRED));
+
+      const response = await appClient["external-account"].$post(
+        { json: input },
+        { headers: { "test-credential-id": "ramp-bridge" } },
+      );
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toStrictEqual({ code: "postal code required" });
+    });
+
+    it("returns 400 when the external account already exists", async () => {
+      vi.spyOn(bridge, "getCustomer").mockResolvedValue(bridgeCustomer);
+      vi.spyOn(bridge, "createExternalAccount").mockRejectedValue(
+        new Error(bridge.ErrorCodes.EXTERNAL_ACCOUNT_ALREADY_EXISTS),
+      );
+
+      const response = await appClient["external-account"].$post(
+        { json: input },
+        { headers: { "test-credential-id": "ramp-bridge" } },
+      );
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toStrictEqual({ code: "external account already exists" });
+    });
+
+    it("returns 500 when bridge util throws an unexpected error", async () => {
+      vi.spyOn(bridge, "getCustomer").mockResolvedValue(bridgeCustomer);
+      vi.spyOn(bridge, "createExternalAccount").mockRejectedValue(new Error("unexpected"));
+
+      const response = await appClient["external-account"].$post(
+        { json: input },
+        { headers: { "test-credential-id": "ramp-bridge" } },
+      );
+
+      expect(response.status).toBe(500);
+    });
+
+    it("delegates to createExternalAccount and returns the external account", async () => {
+      vi.spyOn(bridge, "getCustomer").mockResolvedValue(bridgeCustomer);
+      const createSpy = vi.spyOn(bridge, "createExternalAccount").mockResolvedValue(externalAccount);
+
+      const response = await appClient["external-account"].$post(
+        { json: input },
+        { headers: { "test-credential-id": "ramp-bridge" } },
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toStrictEqual(externalAccount);
+      expect(createSpy).toHaveBeenCalledWith(bridgeCustomer, input);
+    });
+  });
+
+  describe("list external accounts", () => {
+    it("returns 400 for no credential", async () => {
+      const response = await appClient["external-account"].$get(
+        {},
+        { headers: { "test-credential-id": "non-existent" } },
+      );
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toStrictEqual({ code: "no credential" });
+    });
+
+    it("returns 400 when bridgeId is missing", async () => {
+      const response = await appClient["external-account"].$get({}, { headers: { "test-credential-id": "ramp-test" } });
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toStrictEqual({ code: "not started" });
+    });
+
+    it("returns 400 when bridge customer not found", async () => {
+      vi.spyOn(bridge, "getCustomer").mockResolvedValue(undefined); // eslint-disable-line unicorn/no-useless-undefined
+      const listSpy = vi.spyOn(bridge, "listExternalAccounts");
+
+      const response = await appClient["external-account"].$get(
+        {},
+        { headers: { "test-credential-id": "ramp-bridge" } },
+      );
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toStrictEqual({ code: "not started" });
+      expect(listSpy).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 when customer is not active", async () => {
+      vi.spyOn(bridge, "getCustomer").mockResolvedValue({ ...bridgeCustomer, status: "under_review" });
+      const listSpy = vi.spyOn(bridge, "listExternalAccounts");
+
+      const response = await appClient["external-account"].$get(
+        {},
+        { headers: { "test-credential-id": "ramp-bridge" } },
+      );
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toStrictEqual({ code: "not approved" });
+      expect(listSpy).not.toHaveBeenCalled();
+    });
+
+    it("delegates to listExternalAccounts and returns the external accounts", async () => {
+      vi.spyOn(bridge, "getCustomer").mockResolvedValue(bridgeCustomer);
+      const listSpy = vi.spyOn(bridge, "listExternalAccounts").mockResolvedValue([externalAccount]);
+
+      const response = await appClient["external-account"].$get(
+        {},
+        { headers: { "test-credential-id": "ramp-bridge" } },
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toStrictEqual([externalAccount]);
+      expect(listSpy).toHaveBeenCalledWith("bridge-customer-123");
+    });
+  });
+
+  describe("update external account", () => {
+    const address = { streetLine1: "10 Downing St", city: "London", state: "ENG", country: "GBR", postalCode: "SW1A" };
+
+    it("returns 400 for no credential", async () => {
+      const response = await appClient["external-account"][":id"].$patch(
+        { param: { id: "ext-acc-1" }, json: { currency: "USD", address } },
+        { headers: { "test-credential-id": "non-existent" } },
+      );
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toStrictEqual({ code: "no credential" });
+    });
+
+    it("returns 400 when bridgeId is missing", async () => {
+      const response = await appClient["external-account"][":id"].$patch(
+        { param: { id: "ext-acc-1" }, json: { currency: "USD", address } },
+        { headers: { "test-credential-id": "ramp-test" } },
+      );
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toStrictEqual({ code: "not started" });
+    });
+
+    it("returns 400 when bridge customer not found", async () => {
+      vi.spyOn(bridge, "getCustomer").mockResolvedValue(undefined); // eslint-disable-line unicorn/no-useless-undefined
+      const updateSpy = vi.spyOn(bridge, "updateExternalAccount");
+
+      const response = await appClient["external-account"][":id"].$patch(
+        { param: { id: "ext-acc-1" }, json: { currency: "USD", address } },
+        { headers: { "test-credential-id": "ramp-bridge" } },
+      );
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toStrictEqual({ code: "not started" });
+      expect(updateSpy).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 when customer is not active", async () => {
+      vi.spyOn(bridge, "getCustomer").mockResolvedValue({ ...bridgeCustomer, status: "under_review" });
+      const updateSpy = vi.spyOn(bridge, "updateExternalAccount");
+
+      const response = await appClient["external-account"][":id"].$patch(
+        { param: { id: "ext-acc-1" }, json: { currency: "USD", address } },
+        { headers: { "test-credential-id": "ramp-bridge" } },
+      );
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toStrictEqual({ code: "not approved" });
+      expect(updateSpy).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 for input without currency", async () => {
+      const updateSpy = vi.spyOn(bridge, "updateExternalAccount");
+
+      const response = await appClient["external-account"][":id"].$patch(
+        { param: { id: "ext-acc-1" }, json: { address } as never },
+        { headers: { "test-credential-id": "ramp-bridge" } },
+      );
+
+      expect(response.status).toBe(400);
+      expect(updateSpy).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 when external account is not found", async () => {
+      vi.spyOn(bridge, "getCustomer").mockResolvedValue(bridgeCustomer);
+      vi.spyOn(bridge, "updateExternalAccount").mockRejectedValue(
+        new Error(bridge.ErrorCodes.EXTERNAL_ACCOUNT_NOT_FOUND),
+      );
+
+      const response = await appClient["external-account"][":id"].$patch(
+        { param: { id: "ext-acc-missing" }, json: { currency: "USD", address } },
+        { headers: { "test-credential-id": "ramp-bridge" } },
+      );
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toStrictEqual({ code: "external account not found" });
+    });
+
+    it("returns 500 when bridge util throws an unexpected error", async () => {
+      vi.spyOn(bridge, "getCustomer").mockResolvedValue(bridgeCustomer);
+      vi.spyOn(bridge, "updateExternalAccount").mockRejectedValue(new Error("unexpected"));
+
+      const response = await appClient["external-account"][":id"].$patch(
+        { param: { id: "ext-acc-1" }, json: { currency: "USD", address } },
+        { headers: { "test-credential-id": "ramp-bridge" } },
+      );
+
+      expect(response.status).toBe(500);
+    });
+
+    it("delegates to updateExternalAccount and returns the external account", async () => {
+      vi.spyOn(bridge, "getCustomer").mockResolvedValue(bridgeCustomer);
+      const updateSpy = vi.spyOn(bridge, "updateExternalAccount").mockResolvedValue(externalAccount);
+
+      const response = await appClient["external-account"][":id"].$patch(
+        {
+          param: { id: "ext-acc-1" },
+          json: { currency: "USD", address, account: { routingNumber: "121000248" } },
+        },
+        { headers: { "test-credential-id": "ramp-bridge" } },
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toStrictEqual(externalAccount);
+      expect(updateSpy).toHaveBeenCalledWith(bridgeCustomer, "ext-acc-1", {
+        currency: "USD",
+        address,
+        account: { routingNumber: "121000248" },
+      });
+    });
+
+    it("drops account for non-us accounts", async () => {
+      vi.spyOn(bridge, "getCustomer").mockResolvedValue(bridgeCustomer);
+      const updateSpy = vi
+        .spyOn(bridge, "updateExternalAccount")
+        .mockResolvedValue({ ...externalAccount, currency: "EUR", addressValid: undefined });
+
+      const response = await appClient["external-account"][":id"].$patch(
+        {
+          param: { id: "ext-acc-1" },
+          json: { currency: "EUR", address, account: { routingNumber: "121000248" } } as never,
+        },
+        { headers: { "test-credential-id": "ramp-bridge" } },
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toStrictEqual({
+        bankName: "Test Bank",
+        currency: "EUR",
+        id: "ext-acc-1",
+        ownerName: "John Doe",
+      });
+      expect(updateSpy).toHaveBeenCalledWith(bridgeCustomer, "ext-acc-1", { currency: "EUR", address });
+    });
+  });
+
   describe("delete external account", () => {
     it("returns 400 for no credential", async () => {
       const response = await appClient["external-account"][":id"].$delete(
@@ -1284,6 +1631,19 @@ describe("ramp api", () => {
       await expect(response.json()).resolves.toStrictEqual({ code: "external account not found" });
     });
 
+    it("returns 400 when a withdrawal is in progress", async () => {
+      vi.spyOn(bridge, "getCustomer").mockResolvedValue(bridgeCustomer);
+      vi.spyOn(bridge, "removeExternalAccount").mockRejectedValue(new Error(bridge.ErrorCodes.TRANSFER_IN_USE));
+
+      const response = await appClient["external-account"][":id"].$delete(
+        { param: { id: "ext-acc-1" } },
+        { headers: { "test-credential-id": "ramp-bridge" } },
+      );
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toStrictEqual({ code: "withdrawal in progress" });
+    });
+
     it("returns 500 when bridge util throws an unexpected error", async () => {
       vi.spyOn(bridge, "getCustomer").mockResolvedValue(bridgeCustomer);
       vi.spyOn(bridge, "removeExternalAccount").mockRejectedValue(new Error("unexpected"));
@@ -1328,4 +1688,12 @@ const bridgeCustomer = {
   email: "test@example.com",
   status: "active" as const,
   endorsements: [],
+};
+
+const externalAccount = {
+  addressValid: true,
+  bankName: "Test Bank",
+  currency: "USD" as const,
+  id: "ext-acc-1",
+  ownerName: "John Doe",
 };

--- a/server/test/utils/bridge.test.ts
+++ b/server/test/utils/bridge.test.ts
@@ -2608,8 +2608,9 @@ describe("bridge utils", () => {
       );
     });
 
-    it("throws TRANSFER_IN_USE when an existing template is not in awaiting_funds state", async () => {
-      vi.spyOn(globalThis, "fetch")
+    it("reuses an existing static template that is not in awaiting_funds state", async () => {
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
         .mockResolvedValueOnce(fetchResponse(externalAccountResponse("usd")))
         .mockResolvedValueOnce(
           fetchResponse({
@@ -2623,9 +2624,13 @@ describe("bridge utils", () => {
           }),
         );
 
-      await expect(bridge.getOfframpDepositDetails("ext-acc-1", account, activeCustomer, "USD")).rejects.toThrow(
-        bridge.ErrorCodes.TRANSFER_IN_USE,
-      );
+      const result = await bridge.getOfframpDepositDetails("ext-acc-1", account, activeCustomer, "USD");
+
+      expect(result).toStrictEqual([
+        { network: "OPTIMISM", displayName: "Optimism", address: deposit, fee: "0.0", estimatedProcessingTime: "300" },
+      ]);
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+      expect(fetchSpy.mock.calls.every((call) => call[1]?.method !== "POST")).toBe(true);
     });
 
     it("ignores canceled templates and creates a new transfer", async () => {
@@ -2888,6 +2893,82 @@ describe("bridge utils", () => {
         }),
       ).rejects.toThrow(bridge.ErrorCodes.NO_ENDORSEMENT);
       expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("throws INVALID_BANK_NAME when bridge cannot determine the bank name", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+        fetchError(
+          400,
+          '{"code":"invalid_parameters","message":"Please resubmit the following parameters that are either missing or invalid","source":{"location":"body","key":{"bank_name":"must be provided for this routing number as we are unable to determine the name automatically"}}}',
+        ),
+      );
+
+      await expect(
+        bridge.createExternalAccount(activeCustomerWithBaseEndorsement, {
+          currency: "USD",
+          accountOwnerName: "John Doe",
+          accountNumber: "1210002481111",
+          routingNumber: "121000248",
+          address: usdAddress,
+        }),
+      ).rejects.toThrow(bridge.ErrorCodes.INVALID_BANK_NAME);
+    });
+
+    it("throws POSTAL_CODE_REQUIRED when bridge requires the postal code", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+        fetchError(
+          400,
+          '{"code":"invalid_parameters","message":"Please resubmit the following parameters that are either missing or invalid","source":{"location":"body","key":{"address.postal_code":"is required"}}}',
+        ),
+      );
+
+      await expect(
+        bridge.createExternalAccount(activeCustomerWithBaseEndorsement, {
+          currency: "USD",
+          accountOwnerName: "John Doe",
+          accountNumber: "1210002481111",
+          routingNumber: "121000248",
+          address: usdAddress,
+        }),
+      ).rejects.toThrow(bridge.ErrorCodes.POSTAL_CODE_REQUIRED);
+    });
+
+    it("throws EXTERNAL_ACCOUNT_ALREADY_EXISTS when the account is a duplicate", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+        fetchError(
+          400,
+          '{"id":"f9d1715c-0196-4fe2-84a7-385568b86d0c","code":"duplicate_external_account","message":"An external account with the same information has already been added for this customer"}',
+        ),
+      );
+
+      await expect(
+        bridge.createExternalAccount(activeCustomerWithBaseEndorsement, {
+          currency: "USD",
+          accountOwnerName: "John Doe",
+          accountNumber: "1210002481111",
+          routingNumber: "121000248",
+          address: usdAddress,
+        }),
+      ).rejects.toThrow(bridge.ErrorCodes.EXTERNAL_ACCOUNT_ALREADY_EXISTS);
+    });
+
+    it("rethrows other invalid_parameters errors", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+        fetchError(
+          400,
+          '{"code":"invalid_parameters","message":"Please resubmit","source":{"location":"body","key":{"account.routing_number":"is not valid"}}}',
+        ),
+      );
+
+      await expect(
+        bridge.createExternalAccount(activeCustomerWithBaseEndorsement, {
+          currency: "USD",
+          accountOwnerName: "John Doe",
+          accountNumber: "1210002481111",
+          routingNumber: "121000248",
+          address: usdAddress,
+        }),
+      ).rejects.toThrow("Please resubmit");
     });
 
     it("posts a US bank account to bridge and returns the ExternalAccount shape", async () => {
@@ -3362,6 +3443,7 @@ describe("bridge utils", () => {
         .mockResolvedValueOnce(fetchResponse(externalAccountResponse("usd")));
 
       const result = await bridge.updateExternalAccount(activeCustomer, "ext-acc-1", {
+        currency: "USD",
         address,
         account: { routingNumber: "121000248", checkingOrSavings: "savings" },
       });
@@ -3395,6 +3477,7 @@ describe("bridge utils", () => {
         .mockResolvedValueOnce(fetchResponse(externalAccountResponse("usd")));
 
       await bridge.updateExternalAccount(activeCustomer, "ext-acc-1", {
+        currency: "USD",
         account: { routingNumber: "121000248" },
       });
 
@@ -3406,9 +3489,9 @@ describe("bridge utils", () => {
     it("omits account when not provided", async () => {
       const fetchSpy = vi
         .spyOn(globalThis, "fetch")
-        .mockResolvedValueOnce(fetchResponse(externalAccountResponse("eur")));
+        .mockResolvedValueOnce(fetchResponse(externalAccountResponse("usd")));
 
-      await bridge.updateExternalAccount(activeCustomer, "ext-acc-1", { address });
+      await bridge.updateExternalAccount(activeCustomer, "ext-acc-1", { currency: "USD", address });
 
       expect(JSON.parse(fetchSpy.mock.calls[0]?.[1]?.body as string)).toStrictEqual({
         address: {
@@ -3421,32 +3504,76 @@ describe("bridge utils", () => {
       });
     });
 
+    it("maps a missing beneficiary_address_valid for non-us accounts", async () => {
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValueOnce(fetchResponse(externalAccountResponse("eur")));
+
+      const result = await bridge.updateExternalAccount(activeCustomer, "ext-acc-1", { currency: "EUR", address });
+
+      expect(result).toStrictEqual({
+        addressValid: undefined,
+        bankName: "Test Bank",
+        currency: "EUR",
+        id: "ext-acc-1",
+        ownerName: "John Doe",
+      });
+      expect(JSON.parse(fetchSpy.mock.calls[0]?.[1]?.body as string)).toStrictEqual({
+        address: {
+          street_line_1: "10 Downing St",
+          city: "London",
+          state: "ENG",
+          country: "GBR",
+          postal_code: "SW1A",
+        },
+      });
+    });
+
     it("rejects empty update payloads at the schema level", () => {
-      const result = safeParse(bridge.UpdateExternalAccountInput, {});
+      const result = safeParse(bridge.UpdateExternalAccountInput, { currency: "USD" });
       expect(result.success).toBe(false);
       expect(result.issues?.[0]?.message).toBe("address or account is required");
     });
 
     it("rejects account-only updates with no fields at the schema level", () => {
-      const result = safeParse(bridge.UpdateExternalAccountInput, { account: {} });
+      const result = safeParse(bridge.UpdateExternalAccountInput, { currency: "USD", account: {} });
       expect(result.success).toBe(false);
       expect(result.issues?.[0]?.message).toBe("account requires at least one field");
+    });
+
+    it("rejects non-us updates without address at the schema level", () => {
+      const result = safeParse(bridge.UpdateExternalAccountInput, {
+        currency: "EUR",
+        account: { routingNumber: "121000248" },
+      });
+      expect(result.success).toBe(false);
+      expect(result.issues?.some((issue) => issue.path?.at(-1)?.key === "address")).toBe(true);
+    });
+
+    it("drops account for non-us updates at the schema level", () => {
+      const result = safeParse(bridge.UpdateExternalAccountInput, {
+        currency: "EUR",
+        address,
+        account: { routingNumber: "121000248" },
+      });
+      expect(result.success).toBe(true);
+      expect(result.output).toStrictEqual({ currency: "EUR", address });
     });
 
     it("normalizes bridge 404 into EXTERNAL_ACCOUNT_NOT_FOUND", async () => {
       vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(fetchError(404, "not_found"));
 
-      await expect(bridge.updateExternalAccount(activeCustomer, "ext-acc-missing", { address })).rejects.toThrow(
-        bridge.ErrorCodes.EXTERNAL_ACCOUNT_NOT_FOUND,
-      );
+      await expect(
+        bridge.updateExternalAccount(activeCustomer, "ext-acc-missing", { currency: "GBP", address }),
+      ).rejects.toThrow(bridge.ErrorCodes.EXTERNAL_ACCOUNT_NOT_FOUND);
     });
 
     it("propagates non-404 bridge errors", async () => {
       vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(fetchError(500, "internal error"));
 
-      await expect(bridge.updateExternalAccount(activeCustomer, "ext-acc-1", { address })).rejects.toThrow(
-        "internal error",
-      );
+      await expect(
+        bridge.updateExternalAccount(activeCustomer, "ext-acc-1", { currency: "GBP", address }),
+      ).rejects.toThrow("internal error");
     });
   });
 
@@ -3465,6 +3592,21 @@ describe("bridge utils", () => {
         expect.stringContaining("/customers/cust-123/external_accounts?limit=20"),
         expect.objectContaining({ method: "GET" }),
       );
+    });
+
+    it("maps null bank_name and beneficiary_address_valid to undefined", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+        fetchResponse({
+          count: 1,
+          data: [{ ...externalAccountResponse("eur"), bank_name: null, beneficiary_address_valid: null }],
+        }),
+      );
+
+      const result = await bridge.listExternalAccounts("cust-123");
+
+      expect(result).toStrictEqual([
+        { addressValid: undefined, bankName: undefined, currency: "EUR", id: "ext-acc-1", ownerName: "John Doe" },
+      ]);
     });
 
     it("filters out non-fiat currencies", async () => {
@@ -3805,7 +3947,7 @@ function externalAccountResponse(currency: "brl" | "eur" | "gbp" | "mxn" | "usd"
     account_owner_name: "John Doe",
     bank_name: "Test Bank",
     active: true,
-    beneficiary_address_valid: true,
+    ...(currency === "usd" && { beneficiary_address_valid: true }),
   };
 }
 

--- a/server/utils/ramps/bridge.ts
+++ b/server/utils/ramps/bridge.ts
@@ -431,16 +431,29 @@ export async function createExternalAccount(
       }
     })(),
     "POST",
-  ).then(
-    ({ beneficiary_address_valid, bank_name, currency, id, account_owner_name }) =>
-      ({
-        addressValid: beneficiary_address_valid,
-        bankName: bank_name,
-        currency: parse(picklist(FiatCurrency), FiatByBridgeCurrency[currency]),
-        id,
-        ownerName: account_owner_name,
-      }) satisfies InferOutput<typeof ExternalAccount>,
-  );
+  )
+    .catch((error: unknown) => {
+      if (error instanceof ServiceError && typeof error.cause === "string") {
+        if (error.cause.includes(BridgeApiErrorCodes.DUPLICATE_EXTERNAL_ACCOUNT)) {
+          throw new Error(ErrorCodes.EXTERNAL_ACCOUNT_ALREADY_EXISTS);
+        }
+        if (error.cause.includes(BridgeApiErrorCodes.INVALID_PARAMETERS)) {
+          if (error.cause.includes("bank_name")) throw new Error(ErrorCodes.INVALID_BANK_NAME);
+          if (error.cause.includes("address.postal_code")) throw new Error(ErrorCodes.POSTAL_CODE_REQUIRED);
+        }
+      }
+      throw error;
+    })
+    .then(
+      ({ beneficiary_address_valid, bank_name, currency, id, account_owner_name }) =>
+        ({
+          addressValid: beneficiary_address_valid ?? undefined,
+          bankName: bank_name ?? undefined,
+          currency: parse(picklist(FiatCurrency), FiatByBridgeCurrency[currency]),
+          id,
+          ownerName: account_owner_name,
+        }) satisfies InferOutput<typeof ExternalAccount>,
+    );
 }
 
 export function updateExternalAccount(
@@ -461,10 +474,10 @@ export function updateExternalAccount(
         postal_code: update.address.postalCode,
         country: update.address.country,
       },
-      account: update.account && {
-        checking_or_savings: update.account.checkingOrSavings,
-        routing_number: update.account.routingNumber,
-      },
+      account:
+        update.currency === "USD" && update.account
+          ? { checking_or_savings: update.account.checkingOrSavings, routing_number: update.account.routingNumber }
+          : undefined,
     } satisfies InferInput<typeof BridgeUpdateExternalAccount>,
     "PUT",
   )
@@ -481,8 +494,8 @@ export function updateExternalAccount(
     .then(
       (externalAccount) =>
         ({
-          addressValid: externalAccount.beneficiary_address_valid,
-          bankName: externalAccount.bank_name,
+          addressValid: externalAccount.beneficiary_address_valid ?? undefined,
+          bankName: externalAccount.bank_name ?? undefined,
           currency: parse(picklist(FiatCurrency), FiatByBridgeCurrency[externalAccount.currency]),
           id: externalAccount.id,
           ownerName: externalAccount.account_owner_name,
@@ -533,8 +546,8 @@ export async function listExternalAccounts(customerId: string) {
     if (!account.active) return [];
     return [
       {
-        addressValid: account.beneficiary_address_valid,
-        bankName: account.bank_name,
+        addressValid: account.beneficiary_address_valid ?? undefined,
+        bankName: account.bank_name ?? undefined,
         currency,
         id: account.id,
         ownerName: account.account_owner_name,
@@ -916,7 +929,6 @@ export async function getOfframpDepositDetails(
       source.currency === "usdc" &&
       state !== "canceled",
   );
-  if (transfer && transfer.state !== "awaiting_funds") throw new Error(ErrorCodes.TRANSFER_IN_USE);
   transfer ??= await createTransfer({
     on_behalf_of: customer.id,
     client_reference_id: account,
@@ -1547,24 +1559,28 @@ export const ExternalAccountInput = variant("currency", [
   }),
 ]);
 
-export const UpdateExternalAccountInput = pipe(
-  object({
-    address: optional(AddressInput),
-    account: optional(
-      pipe(
-        object({
-          checkingOrSavings: optional(picklist(["checking", "savings"])),
-          routingNumber: optional(RoutingNumber),
-        }),
-        check(
-          ({ checkingOrSavings, routingNumber }) => checkingOrSavings !== undefined || routingNumber !== undefined,
-          "account requires at least one field",
+export const UpdateExternalAccountInput = variant("currency", [
+  pipe(
+    object({
+      currency: literal("USD"),
+      address: optional(AddressInput),
+      account: optional(
+        pipe(
+          object({
+            checkingOrSavings: optional(picklist(["checking", "savings"])),
+            routingNumber: optional(RoutingNumber),
+          }),
+          check(
+            ({ checkingOrSavings, routingNumber }) => checkingOrSavings !== undefined || routingNumber !== undefined,
+            "account requires at least one field",
+          ),
         ),
       ),
-    ),
-  }),
-  check(({ address, account }) => address !== undefined || account !== undefined, "address or account is required"),
-);
+    }),
+    check(({ address, account }) => address !== undefined || account !== undefined, "address or account is required"),
+  ),
+  object({ currency: picklist(["BRL", "EUR", "GBP", "MXN"]), address: AddressInput }),
+]);
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars -- type-only usage
 const BridgeCreateExternalAccount = variant("account_type", [
@@ -1758,15 +1774,15 @@ const BridgeExternalAccount = object({
   account_type: string(),
   currency: picklist(BridgeCurrency),
   account_owner_name: string(),
-  bank_name: optional(string()),
+  bank_name: nullish(string()),
   active: boolean(),
-  beneficiary_address_valid: boolean(),
+  beneficiary_address_valid: nullish(boolean()),
 });
 
 const ExternalAccounts = object({ count: number(), data: array(BridgeExternalAccount) });
 
 export const ExternalAccount = object({
-  addressValid: boolean(),
+  addressValid: optional(boolean()),
   bankName: optional(string()),
   currency: picklist(FiatCurrency),
   id: string(),
@@ -2084,10 +2100,12 @@ export const ErrorCodes = {
   BAD_BRIDGE_ID: "bad bridge id",
   DENYLISTED_COUNTRY: "denylisted country",
   EMAIL_ALREADY_EXISTS: "email already exists",
+  EXTERNAL_ACCOUNT_ALREADY_EXISTS: "external account already exists",
   EXTERNAL_ACCOUNT_CURRENCY_MISMATCH: "external account currency mismatch",
   EXTERNAL_ACCOUNT_NOT_FOUND: "external account not found",
   INVALID_ACCOUNT: "invalid destination account",
   INVALID_ADDRESS: "invalid address",
+  INVALID_BANK_NAME: "invalid bank name",
   INVALID_DEPOSIT_ADDRESS: "invalid deposit address",
   NOT_ACTIVE_CUSTOMER: "not active customer",
   NO_ENDORSEMENT: "no endorsement",
@@ -2103,10 +2121,12 @@ export const ErrorCodes = {
   NO_DOCUMENT_FILE: "no document file",
   NO_PERSONA_ACCOUNT: "no persona account",
   NO_SOCIAL_SECURITY_NUMBER: "no social security number",
+  POSTAL_CODE_REQUIRED: "postal code required",
   TRANSFER_IN_USE: "transfer in use",
 };
 
 const BridgeApiErrorCodes = {
+  DUPLICATE_EXTERNAL_ACCOUNT: "duplicate_external_account",
   EMAIL_ALREADY_EXISTS: "A customer with this email already exists",
   INVALID_PARAMETERS: "invalid_parameters",
   NOT_FOUND: "not_found",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Fixed bridge schema handling for non-US external accounts, including currency-specific request/response mapping.
* Improved `POST /external-account` error translations for invalid bank name, postal code requirement, and already-existing external accounts.
* Updated `update external account` behavior so non-USD currencies omit account details appropriately, and bridge null values now map to optional fields.

## Tests
* Added comprehensive test coverage for create, list, update, and delete external-account flows, including edge cases and new error handling.
* Expanded bridge mapping and schema validation tests for USD vs non-USD update payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->