### PR TITLE
🦺 server: send travel rule data when creating virtual accounts

### DIFF
--- a/.changeset/lucky-falcons-attest.md
+++ b/.changeset/lucky-falcons-attest.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+🦺 send travel rule data when creating virtual accounts

--- a/server/test/utils/bridge.test.ts
+++ b/server/test/utils/bridge.test.ts
@@ -1910,13 +1910,28 @@ describe("bridge utils", () => {
     });
 
     it("creates virtual account when none exists", async () => {
-      vi.spyOn(globalThis, "fetch")
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
         .mockResolvedValueOnce(fetchResponse({ count: 0, data: [] }))
         .mockResolvedValueOnce(fetchResponse(usdVirtualAccount(account)));
 
       const result = await bridge.getDepositDetails("USD", account, activeCustomerWithBaseEndorsement);
 
       expect(result).toHaveLength(2);
+      const createCall = fetchSpy.mock.calls[1];
+      expect(createCall?.[0]).toContain("/virtual_accounts");
+      expect(JSON.parse(createCall?.[1]?.body as string)).toStrictEqual({
+        source: { currency: "usd" },
+        developer_fee_percentage: "0.0",
+        destination: { currency: "usdc", payment_rail: "optimism", address: account },
+        travel_rule_data: {
+          beneficiary: {
+            is_self: true,
+            wallet_type: "self_custodied", // cspell:ignore custodied
+            wallet_attested_ownership_at: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/) as unknown,
+          },
+        },
+      });
     });
 
     it("returns EUR deposit details with SEPA info", async () => {

--- a/server/utils/ramps/bridge.ts
+++ b/server/utils/ramps/bridge.ts
@@ -854,6 +854,13 @@ export async function getDepositDetails(
     source: { currency: CurrencyToBridge[currency] },
     developer_fee_percentage: "0.0",
     destination: { currency: "usdc", payment_rail: supportedChainId, address: account },
+    travel_rule_data: {
+      beneficiary: {
+        is_self: true,
+        wallet_type: "self_custodied", // cspell:ignore custodied
+        wallet_attested_ownership_at: new Date().toISOString(),
+      },
+    },
   });
 
   return getDepositDetailsFromVirtualAccount(virtualAccount, account);
@@ -1391,6 +1398,13 @@ const CreateVirtualAccount = object({
     currency: picklist(["usdc"]),
     payment_rail: picklist(BridgeChain),
     address: Address,
+  }),
+  travel_rule_data: object({
+    beneficiary: object({
+      is_self: boolean(),
+      wallet_type: picklist(["external", "hosted", "self_custodied"]), // cspell:ignore custodied
+      wallet_attested_ownership_at: string(),
+    }),
   }),
 });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Virtual account creation now includes travel rule data containing beneficiary information, including wallet custody designation and account attestation timestamp.

* **Tests**
  * Enhanced test coverage to validate travel rule data structure and ensure all required beneficiary fields, including custody type and verification timestamp, are correctly included in virtual account requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->