### PR TITLE
✨ server: handle failed manteca onboarding tasks

### DIFF
--- a/.changeset/brave-otters-guard.md
+++ b/.changeset/brave-otters-guard.md
@@ -1,0 +1,5 @@
+---
+"@exactly/server": patch
+---
+
+✨ handle failed manteca onboarding tasks

--- a/server/api/ramp.ts
+++ b/server/api/ramp.ts
@@ -181,6 +181,7 @@ export default new Hono()
         case "manteca": {
           const mantecaUser = await manteca.getUser(account);
           if (!mantecaUser) return c.json({ code: ErrorCodes.NOT_STARTED }, 400);
+          if (mantecaUser.status !== "ACTIVE") return c.json({ code: ErrorCodes.NOT_APPROVED }, 400);
           try {
             const depositInfo: InferOutput<typeof RampResponse>["depositInfo"] = manteca.getDepositDetails(
               query.currency,
@@ -614,7 +615,7 @@ const RampResponse = object({
   ),
 });
 
-const ProviderStatus = picklist(["ACTIVE", "NOT_AVAILABLE", "NOT_STARTED", "ONBOARDING"]);
+const ProviderStatus = picklist(["ACTIVE", "CONTACT_SUPPORT", "NOT_AVAILABLE", "NOT_STARTED", "ONBOARDING"]);
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const ProviderInfo = variant("provider", [

--- a/server/test/api/ramp.test.ts
+++ b/server/test/api/ramp.test.ts
@@ -200,6 +200,20 @@ describe("ramp api", () => {
         await expect(response.json()).resolves.toStrictEqual({ code: "not started" });
       });
 
+      it("returns 400 if manteca user is not active", async () => {
+        vi.spyOn(manteca, "getUser").mockResolvedValue({ ...mantecaUser, status: "ONBOARDING" });
+        const depositSpy = vi.spyOn(manteca, "getDepositDetails");
+
+        const response = await appClient.quote.$get(
+          { query: { provider: "manteca", currency: "ARS" } },
+          { headers: { "test-credential-id": "ramp-test" } },
+        );
+
+        expect(response.status).toBe(400);
+        await expect(response.json()).resolves.toStrictEqual({ code: "not approved" });
+        expect(depositSpy).not.toHaveBeenCalled();
+      });
+
       it("returns quote and deposit info for manteca ARS", async () => {
         vi.spyOn(manteca, "getUser").mockResolvedValue(mantecaUser);
         vi.spyOn(manteca, "getQuote").mockResolvedValue({ buyRate: "1000", sellRate: "1010" });

--- a/server/test/utils/manteca.test.ts
+++ b/server/test/utils/manteca.test.ts
@@ -369,6 +369,54 @@ describe("manteca utils", () => {
       expect(result.status).toBe("NOT_STARTED");
     });
 
+    it("returns CONTACT_SUPPORT when user has failed required tasks", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+        mockFetchResponse({
+          ...mockOnboardingUser,
+          onboarding: {
+            EMAIL_VALIDATION: { required: true, status: "COMPLETED" },
+            IDENTITY_VALIDATION: { required: true, status: "FAILED", rejectionReason: "document unreadable" },
+          },
+        }),
+      );
+
+      const result = await manteca.getProvider(account, "AR");
+
+      expect(result.status).toBe("CONTACT_SUPPORT");
+    });
+
+    it("prioritizes CONTACT_SUPPORT over pending required tasks", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+        mockFetchResponse({
+          ...mockOnboardingUser,
+          onboarding: {
+            EMAIL_VALIDATION: { required: true, status: "PENDING" },
+            IDENTITY_VALIDATION: { required: true, status: "FAILED" },
+          },
+        }),
+      );
+
+      const result = await manteca.getProvider(account, "AR");
+
+      expect(result.status).toBe("CONTACT_SUPPORT");
+    });
+
+    it("ignores failed tasks that are not required", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+        mockFetchResponse({
+          ...mockOnboardingUser,
+          onboarding: {
+            EMAIL_VALIDATION: { required: true, status: "COMPLETED" },
+            IDENTITY_VALIDATION: { required: false, status: "FAILED" },
+          },
+        }),
+      );
+
+      const result = await manteca.getProvider(account, "AR");
+
+      expect(result.status).toBe("ONBOARDING");
+    });
+
     it("returns ONBOARDING when user has no pending required tasks", async () => {
       vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
         mockFetchResponse({

--- a/server/utils/ramps/manteca.ts
+++ b/server/utils/ramps/manteca.ts
@@ -252,6 +252,23 @@ export async function getProvider(account: Address, countryCode?: string) {
   if (mantecaUser.status === "INACTIVE") {
     return { onramp: { currencies: [] }, status: "NOT_AVAILABLE" as const };
   }
+  const hasFailedTasks = Object.values(mantecaUser.onboarding).some(
+    (task) => task.required && task.status === "FAILED",
+  );
+  if (hasFailedTasks) {
+    withScope((scope) => {
+      scope.addEventProcessor((event) => {
+        if (event.exception?.values?.[0]) event.exception.values[0].type = "has failed tasks";
+        return event;
+      });
+      captureException(new Error("has failed tasks"), {
+        level: "warning",
+        fingerprint: ["{{ default }}", "has failed tasks"],
+        contexts: { onboarding: mantecaUser.onboarding },
+      });
+    });
+    return { onramp: { currencies }, status: "CONTACT_SUPPORT" as const };
+  }
   const hasPendingTasks = Object.values(mantecaUser.onboarding).some(
     (task) => task.required && task.status === "PENDING",
   );
@@ -264,7 +281,7 @@ export async function getProvider(account: Address, countryCode?: string) {
       captureException(new Error("has pending tasks"), {
         level: "warning",
         fingerprint: ["{{ default }}", "has pending tasks"],
-        contexts: { mantecaUser },
+        contexts: { onboarding: mantecaUser.onboarding },
       });
     });
     return { onramp: { currencies }, status: "NOT_STARTED" as const };
@@ -468,7 +485,7 @@ export const BalancesResponse = object({
   updatedAt: string(),
 });
 
-const onboardingTaskStatus = ["PENDING", "COMPLETED", "IN_PROGRESS"] as const;
+const onboardingTaskStatus = ["PENDING", "COMPLETED", "FAILED", "IN_PROGRESS"] as const;
 const OnboardingTaskInfo = optional(
   object({
     required: boolean(),

--- a/src/components/ramp/RampButton.tsx
+++ b/src/components/ramp/RampButton.tsx
@@ -24,7 +24,7 @@ export default function RampButton({
   direction: "offramp" | "onramp";
   network?: string;
   provider: "bridge" | "manteca";
-  status: "ACTIVE" | "NOT_AVAILABLE" | "NOT_STARTED" | "ONBOARDING";
+  status: "ACTIVE" | "CONTACT_SUPPORT" | "NOT_AVAILABLE" | "NOT_STARTED" | "ONBOARDING";
 }) {
   const { t } = useTranslation();
   const router = useRouter();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new support-needed status for failed onboarding tasks.
  * Expanded status handling to recognize failed onboarding task states.

* **Bug Fixes**
  * Quotes for inactive Manteca accounts now return a clearer “not approved” response instead of proceeding.
  * Failed required onboarding tasks now surface as a support contact state, improving behavior for affected users.

* **Tests**
  * Added coverage for inactive account quotes and onboarding failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->