### PR TITLE
🐛 app: open pax link in external browser

### DIFF
--- a/.changeset/wicked-vans-nail.md
+++ b/.changeset/wicked-vans-nail.md
@@ -1,0 +1,5 @@
+---
+"@exactly/mobile": patch
+---
+
+🐛 open pax link in external browser

--- a/src/components/benefits/BenefitSheet.tsx
+++ b/src/components/benefits/BenefitSheet.tsx
@@ -73,8 +73,9 @@ export default function BenefitSheet({ benefit, open, onClose }: BenefitSheetPro
               minHeight={64}
               padding="$s4"
               onPress={() => {
-                if (!benefit.url) return;
-                openBrowser(benefit.url.replace("{language}", language.split("-")[0] ?? "en")).catch(reportError);
+                const { url, external } = benefit;
+                if (!url) return;
+                openBrowser(url.replace("{language}", language.split("-")[0] ?? "en"), { external }).catch(reportError);
               }}
             >
               <Button.Text emphasized subHeadline color="$interactiveOnBaseBrandDefault">

--- a/src/components/benefits/BenefitsSection.tsx
+++ b/src/components/benefits/BenefitsSection.tsx
@@ -81,6 +81,7 @@ const BENEFITS = [
     Background: () => <RasterBackground source={PaxImage} />,
     buttonText: "Go to Pax Assistance",
     url: "https://www.paxassistance.com/exacard",
+    external: true,
   },
   {
     id: "visa",

--- a/src/utils/openBrowser.ts
+++ b/src/utils/openBrowser.ts
@@ -1,9 +1,10 @@
+import { Linking } from "react-native";
+
 import { openBrowserAsync } from "expo-web-browser";
 
 import { sdk } from "@farcaster/miniapp-sdk";
 
-export default async function openBrowser(url: string) {
-  await ((await sdk.isInMiniApp())
-    ? sdk.actions.openUrl(url)
-    : openBrowserAsync(url, { windowFeatures: { status: true, menubar: true } }));
+export default async function openBrowser(url: string, { external = false } = {}) {
+  if (await sdk.isInMiniApp()) return sdk.actions.openUrl(url);
+  await (external ? Linking.openURL(url) : openBrowserAsync(url, { windowFeatures: { status: true, menubar: true } }));
 }


### PR DESCRIPTION
closes #1163 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pax links now open in the device’s external browser.
  * Improved error handling when opening benefit links.
  * Preserved in-app link behavior for supported mini-app contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->