### PR TITLE
🔖 release: server@0.2.106

### DIFF
--- a/.changeset/long-carpets-cut.md
+++ b/.changeset/long-carpets-cut.md
@@ -1,5 +1,0 @@
----
-"@exactly/server": patch
----
-
-🐛 fix repeat options and delayed maturity reminders

--- a/.changeset/sunny-sites-shine.md
+++ b/.changeset/sunny-sites-shine.md
@@ -1,5 +1,0 @@
----
-"@exactly/server": patch
----
-
-⬆️ upgrade bullmq

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @exactly/server
 
+## 0.2.106
+
+### Patch Changes
+
+- [#1182](https://github.com/exactly/exa/pull/1182) [`06ff25e`](https://github.com/exactly/exa/commit/06ff25e0cd86c6c86f8f394a7e8e0d5d0da6f3f4) Thanks [@aguxez](https://github.com/aguxez)! - 🐛 fix repeat options and delayed maturity reminders
+
+- [#1182](https://github.com/exactly/exa/pull/1182) [`6a3bc08`](https://github.com/exactly/exa/commit/6a3bc08c4430c1cacdde793a75ca01b56769df53) Thanks [@aguxez](https://github.com/aguxez)! - ⬆️ upgrade bullmq
+
 ## 0.2.105
 
 ### Patch Changes

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exactly/server",
-  "version": "0.2.105",
+  "version": "0.2.106",
   "private": true,
   "scripts": {
     "build": "pkgroll --sourcemap --src . && sentry-cli sourcemaps inject -o exactly -p server dist",


### PR DESCRIPTION
# Releases
## @exactly/server@0.2.106

### Patch Changes

- [#1182](https://github.com/exactly/exa/pull/1182) [`06ff25e`](https://github.com/exactly/exa/commit/06ff25e0cd86c6c86f8f394a7e8e0d5d0da6f3f4) Thanks [@aguxez](https://github.com/aguxez)! - 🐛 fix repeat options and delayed maturity reminders

- [#1182](https://github.com/exactly/exa/pull/1182) [`6a3bc08`](https://github.com/exactly/exa/commit/6a3bc08c4430c1cacdde793a75ca01b56769df53) Thanks [@aguxez](https://github.com/aguxez)! - ⬆️ upgrade bullmq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issues affecting repeat options and delayed maturity reminders.
  * Improved the reliability and timing of scheduled reminders.
* **Maintenance**
  * Released a server patch update with these improvements and related stability enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->